### PR TITLE
[코리] step-4 로그인 구현

### DIFF
--- a/src/main/java/codesquad/springcafe/config/AppConfig.java
+++ b/src/main/java/codesquad/springcafe/config/AppConfig.java
@@ -1,0 +1,20 @@
+package codesquad.springcafe.config;
+
+import codesquad.springcafe.interceptor.AuthenticationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AppConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(new AuthenticationInterceptor())
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/fonts/**", "/js/**", "/images/**", "/", "/users/login", "/users", "/users/join");
+
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -18,6 +18,7 @@ import java.util.List;
 @RequestMapping("/users")
 public class UserController {
 
+    public static final String LOGIN_USER_ID = "loginUserId";
     private final Logger log = LoggerFactory.getLogger(UserController.class);
     private final UserService userService;
 
@@ -59,7 +60,7 @@ public class UserController {
     @PostMapping("/login")
     public String login(@RequestParam String userId, @RequestParam String password, HttpSession httpSession) {
         if (userService.isValidUser(userId, password)) {
-            httpSession.setAttribute("loginUserId", userId);
+            httpSession.setAttribute(LOGIN_USER_ID, userId);
             log.debug("로그인 성공: {}", userId);
             return "redirect:/";
         }
@@ -88,5 +89,11 @@ public class UserController {
         }
         log.debug("user {} update", userUpdateDto.getUserId());
         return "redirect:/users";
+    }
+
+    @PostMapping("/logout")
+    public String logout(HttpSession httpSession) {
+        httpSession.invalidate();
+        return "redirect:/";
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -79,7 +79,11 @@ public class UserController {
     }
 
     @PutMapping("/{userId}")
-    public String updateUser(@PathVariable String userId, @RequestParam("password") String password, @RequestParam("newPassword") String newPassword, @RequestParam("name") String name, @RequestParam("email") String email) {
+    public String updateUser(@PathVariable String userId, @RequestParam("password") String password, @RequestParam("newPassword") String newPassword, @RequestParam("name") String name, @RequestParam("email") String email, HttpSession httpSession) {
+        String loginUserId = (String) httpSession.getAttribute(LOGIN_USER_ID);
+        if (!loginUserId.equals(userId)) {
+            return "redirect:/";
+        }
         UserUpdateDto userUpdateDto = new UserUpdateDto(userId, password, newPassword, name, email);
         try {
             userService.update(userUpdateDto);

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -4,6 +4,7 @@ import codesquad.springcafe.dto.UserProfileDto;
 import codesquad.springcafe.dto.UserUpdateDto;
 import codesquad.springcafe.model.User;
 import codesquad.springcafe.service.UserService;
+import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -51,8 +52,18 @@ public class UserController {
     }
 
     @GetMapping("/login")
-    public String login() {
+    public String getLoginForm() {
         return "user/login";
+    }
+
+    @PostMapping("/login")
+    public String login(@RequestParam String userId, @RequestParam String password, HttpSession httpSession) {
+        if (userService.isValidUser(userId, password)) {
+            httpSession.setAttribute("loginUser", userId);
+            log.debug("로그인 성공: {}", userId);
+            return "redirect:/";
+        }
+        return "redirect:/users/login";
     }
 
     @GetMapping("/join")
@@ -69,6 +80,8 @@ public class UserController {
     @PutMapping("/{userId}")
     public String updateUser(@PathVariable String userId, @RequestParam("password") String password, @RequestParam("newPassword") String newPassword, @RequestParam("name") String name, @RequestParam("email") String email) {
         UserUpdateDto userUpdateDto = new UserUpdateDto(userId, password, newPassword, name, email);
+
+
         try {
             userService.update(userUpdateDto);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController {
     @PostMapping("/login")
     public String login(@RequestParam String userId, @RequestParam String password, HttpSession httpSession) {
         if (userService.isValidUser(userId, password)) {
-            httpSession.setAttribute("loginUser", userId);
+            httpSession.setAttribute("loginUserId", userId);
             log.debug("로그인 성공: {}", userId);
             return "redirect:/";
         }
@@ -80,8 +80,6 @@ public class UserController {
     @PutMapping("/{userId}")
     public String updateUser(@PathVariable String userId, @RequestParam("password") String password, @RequestParam("newPassword") String newPassword, @RequestParam("name") String name, @RequestParam("email") String email) {
         UserUpdateDto userUpdateDto = new UserUpdateDto(userId, password, newPassword, name, email);
-
-
         try {
             userService.update(userUpdateDto);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,23 @@
+package codesquad.springcafe.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    public static final String LOGIN_USER_ID = "loginUserId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        HttpSession session = request.getSession();
+        if (session == null || session.getAttribute(LOGIN_USER_ID) == null) {
+            response.sendRedirect("/users/login?redirectURL=" + requestURI);
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
@@ -12,7 +12,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String requestURI = request.getRequestURI();
-        HttpSession session = request.getSession();
+        HttpSession session = request.getSession(false);
         if (session == null || session.getAttribute(LOGIN_USER_ID) == null) {
             response.sendRedirect("/users/login?redirectURL=" + requestURI);
             return false;

--- a/src/main/java/codesquad/springcafe/model/Article.java
+++ b/src/main/java/codesquad/springcafe/model/Article.java
@@ -4,6 +4,7 @@ import codesquad.springcafe.dto.ArticleRequestDto;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class Article {
 
@@ -12,15 +13,15 @@ public class Article {
     private final String title;
     private final String contents;
     private final LocalDateTime localDateTime;
-    private int hits;
+    private AtomicLong hits;
 
-    public Article(Long articleId, String writer, String title, String contents, LocalDateTime localDateTime, int hits) {
+    public Article(Long articleId, String writer, String title, String contents, LocalDateTime localDateTime, long hits) {
         this.articleId = articleId;
         this.writer = writer;
         this.title = title;
         this.contents = contents;
         this.localDateTime = localDateTime;
-        this.hits = hits;
+        this.hits = new AtomicLong(hits);
     }
 
     public Article(Long articleId, String writer, String title, String contents) {
@@ -29,7 +30,7 @@ public class Article {
         this.title = title;
         this.contents = contents;
         this.localDateTime = LocalDateTime.now();
-        this.hits = 0;
+        this.hits = new AtomicLong();
     }
 
     public Article(long articleId, ArticleRequestDto articleRequestDto) {
@@ -41,7 +42,7 @@ public class Article {
         this.title = articleRequestDto.getTitle();
         this.contents = articleRequestDto.getContents();
         this.localDateTime = LocalDateTime.now();
-        this.hits = 0;
+        this.hits = new AtomicLong();
     }
 
     public Long getArticleId() {
@@ -64,15 +65,12 @@ public class Article {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
-    public int getHits() {
-        return hits;
+    public long getHits() {
+        return hits.get();
     }
 
     public void setArticleId(Long articleId) {
         this.articleId = articleId;
     }
 
-    public void increaseHits() {
-        hits++;
-    }
 }

--- a/src/main/java/codesquad/springcafe/model/User.java
+++ b/src/main/java/codesquad/springcafe/model/User.java
@@ -45,15 +45,15 @@ public class User {
     }
 
     public void update(UserUpdateDto userUpdateDto) {
-        validatePassword(userUpdateDto.getPassword());
+        if (!validatePassword(userUpdateDto.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
         this.name = userUpdateDto.getName();
         this.password = userUpdateDto.getNewPassword();
         this.email = userUpdateDto.getEmail();
     }
 
-    private void validatePassword(String password) {
-        if (!this.password.equals(password)) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-        }
+    public boolean validatePassword(String password) {
+        return this.password.equals(password);
     }
 }

--- a/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
@@ -65,7 +65,7 @@ public class ArticleJdbcRepository implements ArticleRepository {
             String title = rs.getString("title");
             String contents = rs.getString("contents");
             LocalDateTime localDateTime = rs.getTimestamp("local_date_time").toLocalDateTime();
-            int hits = rs.getInt("hits");
+            long hits = rs.getLong("hits");
 
             return new Article(articleId, writer, title, contents, localDateTime, hits);
         };

--- a/src/main/java/codesquad/springcafe/repository/UserJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/UserJdbcRepository.java
@@ -12,12 +12,6 @@ import java.util.List;
 @Primary
 public class UserJdbcRepository implements UserRepository {
 
-    private static final String INSERT_USER_SQL = "INSERT INTO users (user_id, password, name, email) VALUES (?, ?, ?, ?)";
-    private static final String SELECT_ALL_USERS_SQL = "SELECT * FROM users";
-    private static final String SELECT_USER_BY_ID_SQL = "SELECT * FROM users WHERE user_id = ?";
-    private static final String DELETE_ALL_USERS_SQL = "DELETE FROM users";
-    private static final String UPDATE_USER_SQL = "UPDATE users SET password = ?, name = ?, email = ? WHERE user_id = ?";
-
     private final JdbcTemplate jdbcTemplate;
 
     public UserJdbcRepository(JdbcTemplate jdbcTemplate) {
@@ -26,27 +20,32 @@ public class UserJdbcRepository implements UserRepository {
 
     @Override
     public void saveUser(User user) {
-        jdbcTemplate.update(INSERT_USER_SQL, user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
+        String sql = "INSERT INTO users (user_id, password, name, email) VALUES (?, ?, ?, ?)";
+        jdbcTemplate.update(sql, user.getUserId(), user.getPassword(), user.getName(), user.getEmail());
     }
 
     @Override
     public List<User> findAllUsers() {
-        return jdbcTemplate.query(SELECT_ALL_USERS_SQL, userRowMapper());
+        String sql = "SELECT * FROM users";
+        return jdbcTemplate.query(sql, userRowMapper());
     }
 
     @Override
     public User findUserById(String userId) {
-        return jdbcTemplate.queryForObject(SELECT_USER_BY_ID_SQL, userRowMapper(), userId);
+        String sql = "SELECT * FROM users WHERE user_id = ?";
+        return jdbcTemplate.queryForObject(sql, userRowMapper(), userId);
     }
 
     @Override
     public void clear() {
-        jdbcTemplate.update(DELETE_ALL_USERS_SQL);
+        String sql = "DELETE FROM users";
+        jdbcTemplate.update(sql);
     }
 
     @Override
     public void update(User user) {
-        jdbcTemplate.update(UPDATE_USER_SQL, user.getPassword(), user.getName(), user.getEmail(), user.getUserId());
+        String sql = "UPDATE users SET password = ?, name = ?, email = ? WHERE user_id = ?";
+        jdbcTemplate.update(sql, user.getPassword(), user.getName(), user.getEmail(), user.getUserId());
     }
 
     private RowMapper<User> userRowMapper() {

--- a/src/main/java/codesquad/springcafe/service/UserService.java
+++ b/src/main/java/codesquad/springcafe/service/UserService.java
@@ -34,4 +34,10 @@ public class UserService {
         user.update(userUpdateDto);
         userRepository.update(user);
     }
+
+    public boolean isValidUser(String userId, String password) {
+        User user = userRepository.findUserById(userId);
+        return user.validatePassword(password);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.thymeleaf.cache=false
 spring.web.resources.cache.period=3600
 logging.level.root = info
 logging.level.codesquad.springcafe = debug
+logging.level.org.springframework.web=DEBUG
 spring.mvc.hiddenmethod.filter.enabled=true
 spring.datasource.url=jdbc:h2:tcp://localhost/~/spring-qna-db
 spring.datasource.username=sa

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -201,3 +201,9 @@ h3,h4,h5 {
     padding-right: 2.5em;
 }
 
+.navbar-button {
+    padding: 15px;
+    background: none;
+    border: none;
+}
+

--- a/src/main/resources/templates/fragments/base.html
+++ b/src/main/resources/templates/fragments/base.html
@@ -65,14 +65,10 @@
         <div class="collapse navbar-collapse" id="navbar-collapse2">
             <ul class="nav navbar-nav navbar-right">
                 <li class="active"><a href="/">Posts</a></li>
-                <li><a href="/users/login" methods="GET" role="button">로그인</a></li>
-                <li><a href="/users/join" methods="GET" role="button">회원가입</a></li>
-                <!--
-                <li><a href="#loginModal" role="button" data-toggle="modal">로그인</a></li>
-                <li><a href="#registerModal" role="button" data-toggle="modal">회원가입</a></li>
-                -->
-                <li><a href="#" role="button">로그아웃</a></li>
-                <li><a href="#" role="button">개인정보수정</a></li>
+                <li th:if="${session.loginUserId == null}"><a href="/users/login" methods="GET" role="button">로그인</a></li>
+                <li th:if="${session.loginUserId == null}"><a href="/users/join" methods="GET" role="button">회원가입</a></li>
+                <li th:if="${session.loginUserId != null}"><a href="/users/logout" methods="POST" role="button">로그아웃</a></li>
+                <li th:if="${session.loginUserId != null}"><a href="/users/123/form" role="button">개인정보수정</a></li>
             </ul>
         </div>
     </div>

--- a/src/main/resources/templates/fragments/base.html
+++ b/src/main/resources/templates/fragments/base.html
@@ -65,9 +65,14 @@
         <div class="collapse navbar-collapse" id="navbar-collapse2">
             <ul class="nav navbar-nav navbar-right">
                 <li class="active"><a href="/">Posts</a></li>
-                <li th:if="${session.loginUserId == null}"><a href="/users/login" methods="GET" role="button">로그인</a></li>
-                <li th:if="${session.loginUserId == null}"><a href="/users/join" methods="GET" role="button">회원가입</a></li>
-                <li th:if="${session.loginUserId != null}"><a href="/users/logout" methods="POST" role="button">로그아웃</a></li>
+                <li th:if="${session.loginUserId == null}"><a href="/users/login" role="button">로그인</a></li>
+                <li th:if="${session.loginUserId == null}"><a href="/users/join" role="button">회원가입</a></li>
+                <li th:if="${session.loginUserId != null}">
+                    <form th:action="@{/users/logout}" method="post">
+                        <button type="submit" class="btn btn-link navbar-button">로그아웃</button>
+                    </form>
+<!--                    <a href="/users/logout" methods="POST" role="button">로그아웃</a>-->
+                </li>
                 <li th:if="${session.loginUserId != null}"><a th:href="@{/users/{userId}/form(userId = ${session.loginUserId})}" role="button">개인정보수정</a></li>
             </ul>
         </div>

--- a/src/main/resources/templates/fragments/base.html
+++ b/src/main/resources/templates/fragments/base.html
@@ -68,7 +68,7 @@
                 <li th:if="${session.loginUserId == null}"><a href="/users/login" methods="GET" role="button">로그인</a></li>
                 <li th:if="${session.loginUserId == null}"><a href="/users/join" methods="GET" role="button">회원가입</a></li>
                 <li th:if="${session.loginUserId != null}"><a href="/users/logout" methods="POST" role="button">로그아웃</a></li>
-                <li th:if="${session.loginUserId != null}"><a href="/users/123/form" role="button">개인정보수정</a></li>
+                <li th:if="${session.loginUserId != null}"><a th:href="@{/users/{userId}/form(userId = ${session.loginUserId})}" role="button">개인정보수정</a></li>
             </ul>
         </div>
     </div>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -12,7 +12,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="post" action="/user/login">
+          <form name="question" method="post" action="/users/login">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">


### PR DESCRIPTION
## 구현 내용
- [x] 로그인 기능
	- 로그인 할 경우  “로그아웃”, “개인정보수정” 가 상단에 표시
	- 로그인 상태가 아니라면 상단 메뉴에서 “로그인”, “회원가입”이 표시
	- 로그인 하지 않고 로그인해야 접근 가능한 페이지로 접근할 경우 로그인 폼으로 리다이렉트
	- 로그인 하지 않은 상태로 사용 가능한 기능: `글 목록 보가`, `사용자 목록 보기`, `회원가입`,`로그인`
- [x] 로그아웃 기능
- [x] 개인정보 수정
	- 로그인한 사용자의 개인정보만 수정할 수 있도록 변경

| URI                           | 기능          |
| ----------------------------- | ----------- |
| `GET /users`                  | 사용자 목록      |
| `POST /users`                 | 회원 가입 기능    |
| `GET /users/{userId}`         | 회원 프로필 조회   |
| `GET /questions`              | 글쓰기 페이지     |
| `POST /questions`             | 글쓰기 기능      |
| `GET /questions/{questionId}` | 게시글 상세 보기   |
| `GET /users/{userId}/form`    | 회원정보 수정 페이지 |
| `PUT /users/{userId}`         | 회원정보 수정     |
| `POST /users/login`           | 로그인 기능      |
| `POST /users/logout`          | 로그아웃 기능     |

<br><br>

## 고민 사항
- `Interceptor`를 사용해 공통의 기능을 구현할 때 `path` 뿐 아니라 HTTP 메소드 별로 구분하고 싶었는데, 인터셉터를 추가할 때 HTTP 메서드로 구분하는 기능이 존재하지 않았습니다.
  예를 들어 `GET /users (전체 사용자 목록 조회)`에 대해서는 로그인해야 접근할 수 있고, `POST /users (회원가입)`는 로그인 여부에 상관없이 접근할 수 있게 하고 싶은데, 구분이 불가능 했습니다.  
  이걸 위해 이미 컨트롤러에서 매핑한 URI를 수정하는 건 이상한 것 같고, 인터셉터에 HTTP 메서드를 구분하는 로직을 추가하는 것도 이상하다는 생각이 들어 우선은 `GET /users` 요청도 로그인하지 않아도 접근할 수 있게 구현했습니다.  
  아래 코드와 같이 `excludePathPatterns`에 `/users`를 추가하니 `POST /users` 도 `AuthenticationInterceptor`를 거치지 않는데, 어떻게 하면 `GET /users`는 인터셉터를 거치고, `POST /users`는 인터셉터를 거치지 않게 할 수 있을지 고민됩니다.  
```java
registry.addInterceptor(new AuthenticationInterceptor())  
        .addPathPatterns("/**")  
        .excludePathPatterns("/css/**", "/fonts/**", "/js/**", "/images/**", "/", "/users/login", "/users", "/users/join");
```

<br><br>

