### PR TITLE
[yelly] step-6 댓글

### DIFF
--- a/src/main/java/codesquad/springcafe/WebConfig.java
+++ b/src/main/java/codesquad/springcafe/WebConfig.java
@@ -1,7 +1,10 @@
 package codesquad.springcafe;
 
+import codesquad.springcafe.controller.argumentresolver.LoginIdArgumentResolver;
 import codesquad.springcafe.interceptor.LoginInterceptor;
+import java.util.List;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +19,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/", "/css/**", "/fonts/**", "/images/**", "/js/**", "*.ico", "/error/**",
                         "/members/add", "/login", "/logout");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginIdArgumentResolver());
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/codesquad/springcafe/controller/advice/ExceptionControllerAdvice.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.controller.advice;
 
+import codesquad.springcafe.service.exception.DataDeletionException;
 import codesquad.springcafe.service.exception.ResourceNotFoundException;
 import codesquad.springcafe.service.exception.UnauthorizedException;
 import org.slf4j.Logger;
@@ -22,9 +23,16 @@ public class ExceptionControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.FORBIDDEN)
-    @ExceptionHandler
+    @ExceptionHandler(UnauthorizedException.class)
     public String unauthorizedHandler(UnauthorizedException e) {
         log.error("[UnauthorizedException] {}" , e.getMessage());
         return "error/403";
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(DataDeletionException.class)
+    public String dataDeletionHandler(DataDeletionException e) {
+        log.error("[DataDeletionException] {}", e.getMessage());
+        return "error/delete-failed";
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/argumentresolver/LoginId.java
+++ b/src/main/java/codesquad/springcafe/controller/argumentresolver/LoginId.java
@@ -1,0 +1,11 @@
+package codesquad.springcafe.controller.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginId {
+}

--- a/src/main/java/codesquad/springcafe/controller/argumentresolver/LoginIdArgumentResolver.java
+++ b/src/main/java/codesquad/springcafe/controller/argumentresolver/LoginIdArgumentResolver.java
@@ -1,0 +1,33 @@
+package codesquad.springcafe.controller.argumentresolver;
+
+import codesquad.springcafe.controller.SessionConst;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(LoginId.class);
+        boolean hasMemberId = String.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasLoginAnnotation && hasMemberId;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return null;
+        }
+
+        return session.getAttribute(SessionConst.SESSION_ID);
+    }
+}

--- a/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
@@ -1,9 +1,13 @@
 package codesquad.springcafe.controller.article;
 
 import codesquad.springcafe.controller.SessionConst;
+import codesquad.springcafe.controller.comment.CommentForm;
 import codesquad.springcafe.domain.article.Article;
+import codesquad.springcafe.domain.comment.Comment;
 import codesquad.springcafe.service.article.ArticleManager;
+import codesquad.springcafe.service.comment.CommentManager;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -22,10 +26,12 @@ import org.springframework.web.bind.annotation.SessionAttribute;
 @RequestMapping("/questions")
 public class ArticleController {
     private final ArticleManager articleManager;
+    private final CommentManager commentManager;
 
     @Autowired
-    public ArticleController(ArticleManager articleManager) {
+    public ArticleController(ArticleManager articleManager, CommentManager commentManager) {
         this.articleManager = articleManager;
+        this.commentManager = commentManager;
     }
 
     @GetMapping
@@ -51,14 +57,20 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     public String detail(@PathVariable("articleId") long articleId, Model model) {
-        Article findArticle = articleManager.findArticle(articleId);
-
         /* 줄바꿈 문자 추가 */
         String lineSeparator = System.lineSeparator();
         model.addAttribute("lineSeparator", lineSeparator);
 
-        /* 모델 속성 추가 */
+        /* 게시글 추가 */
+        Article findArticle = articleManager.findArticle(articleId);
         model.addAttribute("article", findArticle);
+
+        /* 댓글 리스트 추가 */
+        List<Comment> comments = commentManager.findAllComment(articleId);
+        model.addAttribute("comments", comments);
+
+        /* 댓글 폼 추가 */
+        model.addAttribute("commentForm", new CommentForm());
 
         return "qna/detail";
     }

--- a/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
@@ -1,6 +1,6 @@
 package codesquad.springcafe.controller.article;
 
-import codesquad.springcafe.controller.SessionConst;
+import codesquad.springcafe.controller.argumentresolver.LoginId;
 import codesquad.springcafe.controller.comment.CommentForm;
 import codesquad.springcafe.domain.article.Article;
 import codesquad.springcafe.domain.comment.Comment;
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Controller
 @RequestMapping("/questions")
@@ -35,8 +34,7 @@ public class ArticleController {
     }
 
     @GetMapping
-    public String publish(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                          @ModelAttribute("article") ArticleForm form) {
+    public String publish(@LoginId String loginId, @ModelAttribute("article") ArticleForm form) {
         form.setCreatedBy(loginId);
 
         return "qna/form";
@@ -87,8 +85,8 @@ public class ArticleController {
     }
 
     @GetMapping("/{articleId}/edit")
-    public String editForm(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                           @PathVariable("articleId") long articleId, @ModelAttribute("form") UpdateArticle form) {
+    public String editForm(@LoginId String loginId, @PathVariable("articleId") long articleId,
+                           @ModelAttribute("form") UpdateArticle form) {
         Article findArticle = articleManager.findArticle(articleId);
 
         /* 작성자 검증 */
@@ -108,9 +106,8 @@ public class ArticleController {
     }
 
     @PutMapping("/{articleId}")
-    public String edit(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                       @PathVariable("articleId") long articleId, @Validated @ModelAttribute("form") UpdateArticle form,
-                       BindingResult bindingResult) {
+    public String edit(@LoginId String loginId, @PathVariable("articleId") long articleId,
+                       @Validated @ModelAttribute("form") UpdateArticle form, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "qna/updateForm";
         }
@@ -121,8 +118,7 @@ public class ArticleController {
     }
 
     @GetMapping("/{articleId}/delete")
-    public String confirmUnpublish(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                                  @PathVariable("articleId") long articleId) {
+    public String confirmUnpublish(@LoginId String loginId, @PathVariable("articleId") long articleId) {
         Article findArticle = articleManager.findArticle(articleId);
 
         /* 작성자 검증 */
@@ -132,8 +128,7 @@ public class ArticleController {
     }
 
     @DeleteMapping("/{articleId}")
-    public String unpublish(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                            @PathVariable("articleId") long articleId) {
+    public String unpublish(@LoginId String loginId, @PathVariable("articleId") long articleId) {
         Article findArticle = articleManager.findArticle(articleId);
 
         /* 작성자 검증 */

--- a/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/article/ArticleController.java
@@ -54,7 +54,7 @@ public class ArticleController {
     }
 
     @GetMapping("/{articleId}")
-    public String detail(@PathVariable("articleId") long articleId, Model model) {
+    public String detail(@LoginId String loginId, @PathVariable("articleId") long articleId, Model model) {
         /* 줄바꿈 문자 추가 */
         String lineSeparator = System.lineSeparator();
         model.addAttribute("lineSeparator", lineSeparator);
@@ -69,6 +69,9 @@ public class ArticleController {
 
         /* 댓글 폼 추가 */
         model.addAttribute("commentForm", new CommentForm());
+
+        /* 로그인된 사용자 추가 */
+        model.addAttribute("loginMember", loginId);
 
         return "qna/detail";
     }

--- a/src/main/java/codesquad/springcafe/controller/comment/CommentController.java
+++ b/src/main/java/codesquad/springcafe/controller/comment/CommentController.java
@@ -1,0 +1,98 @@
+package codesquad.springcafe.controller.comment;
+
+import codesquad.springcafe.controller.SessionConst;
+import codesquad.springcafe.domain.comment.Comment;
+import codesquad.springcafe.service.comment.CommentManager;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.SessionAttribute;
+
+@Controller
+@RequestMapping("/questions/{articleId}/comments")
+public class CommentController {
+    private final CommentManager commentManager;
+
+    @Autowired
+    public CommentController(CommentManager commentManager) {
+        this.commentManager = commentManager;
+    }
+
+    @PostMapping
+    public String publishComment(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
+                                 @PathVariable("articleId") long articleId,
+                                 @ModelAttribute("commentForm") CommentForm form) {
+        Comment comment = createComment(loginId, articleId, form);
+
+        commentManager.publish(comment);
+
+        return "redirect:/questions/{articleId}";
+    }
+
+    @GetMapping("/{commentId}/edit")
+    public String editForm(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
+                           @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId,
+                           @ModelAttribute("form") CommentUpdateForm form) {
+        Comment comment = commentManager.findComment(commentId);
+
+        /* 작성자 검증 */
+        commentManager.validateAuthor(loginId, comment.getCreatedBy());
+
+        /* 정상 로직 */
+        fillForm(form, comment);
+
+        return "qna/commentUpdateForm";
+    }
+
+    @PutMapping("/{commentId}")
+    public String edit(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
+                       @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId,
+                       @Validated @ModelAttribute("form") CommentUpdateForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "qna/commentUpdateForm";
+        }
+
+        commentManager.editComment(loginId, form);
+
+        return "redirect:/questions/{articleId}";
+    }
+
+    @DeleteMapping("/{commentId}")
+    public String delete(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
+                         @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId) {
+        Comment comment = commentManager.findComment(commentId);
+
+        /* 작성자 검증 */
+        commentManager.validateAuthor(loginId, comment.getCreatedBy());
+
+        /* 정상 로직 */
+        commentManager.unpublish(commentId);
+
+        return "redirect:/questions/{articleId}";
+    }
+
+    private Comment createComment(String loginId, long articleId, CommentForm form) {
+        Comment comment = new Comment();
+        comment.setArticleId(articleId);
+        comment.setContent(form.getContent());
+        comment.setCreatedBy(loginId);
+        comment.setCreatedAt(LocalDateTime.now());
+        return comment;
+    }
+
+    private void fillForm(CommentUpdateForm form, Comment comment) {
+        form.setId(comment.getId());
+        form.setArticleId(comment.getArticleId());
+        form.setAuthor(comment.getCreatedBy());
+        form.setContent(comment.getContent());
+    }
+}

--- a/src/main/java/codesquad/springcafe/controller/comment/CommentController.java
+++ b/src/main/java/codesquad/springcafe/controller/comment/CommentController.java
@@ -1,6 +1,6 @@
 package codesquad.springcafe.controller.comment;
 
-import codesquad.springcafe.controller.SessionConst;
+import codesquad.springcafe.controller.argumentresolver.LoginId;
 import codesquad.springcafe.domain.comment.Comment;
 import codesquad.springcafe.service.comment.CommentManager;
 import java.time.LocalDateTime;
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.SessionAttribute;
 
 @Controller
 @RequestMapping("/questions/{articleId}/comments")
@@ -28,8 +27,7 @@ public class CommentController {
     }
 
     @PostMapping
-    public String publishComment(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                                 @PathVariable("articleId") long articleId,
+    public String publishComment(@LoginId String loginId, @PathVariable("articleId") long articleId,
                                  @ModelAttribute("commentForm") CommentForm form) {
         Comment comment = createComment(loginId, articleId, form);
 
@@ -39,8 +37,8 @@ public class CommentController {
     }
 
     @GetMapping("/{commentId}/edit")
-    public String editForm(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                           @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId,
+    public String editForm(@LoginId String loginId, @PathVariable("commentId") long commentId,
+                           @PathVariable("articleId") long articleId,
                            @ModelAttribute("form") CommentUpdateForm form) {
         Comment comment = commentManager.findComment(commentId);
 
@@ -54,8 +52,8 @@ public class CommentController {
     }
 
     @PutMapping("/{commentId}")
-    public String edit(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                       @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId,
+    public String edit(@LoginId String loginId, @PathVariable("commentId") long commentId,
+                       @PathVariable("articleId") long articleId,
                        @Validated @ModelAttribute("form") CommentUpdateForm form, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "qna/commentUpdateForm";
@@ -67,8 +65,8 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public String delete(@SessionAttribute(name = SessionConst.SESSION_ID) String loginId,
-                         @PathVariable("commentId") long commentId, @PathVariable("articleId") long articleId) {
+    public String delete(@LoginId String loginId, @PathVariable("commentId") long commentId,
+                         @PathVariable("articleId") long articleId) {
         Comment comment = commentManager.findComment(commentId);
 
         /* 작성자 검증 */

--- a/src/main/java/codesquad/springcafe/controller/comment/CommentForm.java
+++ b/src/main/java/codesquad/springcafe/controller/comment/CommentForm.java
@@ -1,0 +1,17 @@
+package codesquad.springcafe.controller.comment;
+
+public class CommentForm {
+    private String content;
+
+    public CommentForm() {
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public CommentForm setContent(String content) {
+        this.content = content;
+        return this;
+    }
+}

--- a/src/main/java/codesquad/springcafe/controller/comment/CommentUpdateForm.java
+++ b/src/main/java/codesquad/springcafe/controller/comment/CommentUpdateForm.java
@@ -1,0 +1,43 @@
+package codesquad.springcafe.controller.comment;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public class CommentUpdateForm {
+    @NotNull
+    private long id;
+    @NotNull
+    private long articleId;
+    @NotEmpty
+    private String content;
+
+    public CommentUpdateForm() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public CommentUpdateForm setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public long getArticleId() {
+        return articleId;
+    }
+
+    public CommentUpdateForm setArticleId(long articleId) {
+        this.articleId = articleId;
+        return this;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public CommentUpdateForm setContent(String content) {
+        this.content = content;
+        return this;
+    }
+}

--- a/src/main/java/codesquad/springcafe/controller/comment/CommentUpdateForm.java
+++ b/src/main/java/codesquad/springcafe/controller/comment/CommentUpdateForm.java
@@ -9,6 +9,8 @@ public class CommentUpdateForm {
     @NotNull
     private long articleId;
     @NotEmpty
+    private String author;
+    @NotEmpty
     private String content;
 
     public CommentUpdateForm() {
@@ -29,6 +31,15 @@ public class CommentUpdateForm {
 
     public CommentUpdateForm setArticleId(long articleId) {
         this.articleId = articleId;
+        return this;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public CommentUpdateForm setAuthor(String author) {
+        this.author = author;
         return this;
     }
 

--- a/src/main/java/codesquad/springcafe/controller/member/MemberController.java
+++ b/src/main/java/codesquad/springcafe/controller/member/MemberController.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.controller.member;
 
 import codesquad.springcafe.controller.SessionConst;
+import codesquad.springcafe.controller.argumentresolver.LoginId;
 import codesquad.springcafe.domain.member.Member;
 import codesquad.springcafe.service.exception.ResourceNotFoundException;
 import codesquad.springcafe.service.exception.UnauthorizedException;
@@ -74,7 +75,7 @@ public class MemberController {
     }
 
     @GetMapping("/{loginId}/update")
-    public String updateForm(@SessionAttribute(name = SessionConst.SESSION_ID, required = false) String sessionMemberId,
+    public String updateForm(@LoginId String sessionMemberId,
                              @PathVariable("loginId") String loginId, @ModelAttribute("form") UpdateMember form) {
         /* 로그인 검증 */
         validateLoginId(sessionMemberId, loginId);

--- a/src/main/java/codesquad/springcafe/domain/article/Article.java
+++ b/src/main/java/codesquad/springcafe/domain/article/Article.java
@@ -10,6 +10,7 @@ public class Article {
     private String createdBy;
     private LocalDateTime createdAt;
     private boolean deleted = false;
+    private int commentSize;
 
     public Article() {
     }
@@ -75,6 +76,15 @@ public class Article {
 
     public Article softDelete() {
         this.deleted = true;
+        return this;
+    }
+
+    public int getCommentSize() {
+        return commentSize;
+    }
+
+    public Article setCommentSize(int commentSize) {
+        this.commentSize = commentSize;
         return this;
     }
 

--- a/src/main/java/codesquad/springcafe/domain/article/Article.java
+++ b/src/main/java/codesquad/springcafe/domain/article/Article.java
@@ -63,6 +63,11 @@ public class Article {
         return deleted;
     }
 
+    public Article setDeleted(boolean deleted) {
+        this.deleted = deleted;
+        return this;
+    }
+
     public Article restore() {
         this.deleted = false;
         return this;

--- a/src/main/java/codesquad/springcafe/domain/article/Article.java
+++ b/src/main/java/codesquad/springcafe/domain/article/Article.java
@@ -9,6 +9,7 @@ public class Article {
     private String contents;
     private String createdBy;
     private LocalDateTime createdAt;
+    private boolean deleted = false;
 
     public Article() {
     }
@@ -55,6 +56,20 @@ public class Article {
 
     public Article setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
+        return this;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public Article restore() {
+        this.deleted = false;
+        return this;
+    }
+
+    public Article softDelete() {
+        this.deleted = true;
         return this;
     }
 

--- a/src/main/java/codesquad/springcafe/domain/comment/Comment.java
+++ b/src/main/java/codesquad/springcafe/domain/comment/Comment.java
@@ -1,0 +1,78 @@
+package codesquad.springcafe.domain.comment;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+public class Comment {
+    private long id;
+    private long articleId;
+    private String content;
+    private String createdBy;
+    private LocalDateTime createdAt;
+
+    public Comment() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public Comment setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public long getArticleId() {
+        return articleId;
+    }
+
+    public Comment setArticleId(long articleId) {
+        this.articleId = articleId;
+        return this;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Comment setContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public Comment setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+        return this;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public Comment setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Comment comment)) {
+            return false;
+        }
+        return getId() == comment.getId() && getArticleId() == comment.getArticleId() && Objects.equals(getContent(),
+                comment.getContent()) && Objects.equals(getCreatedBy(), comment.getCreatedBy())
+                && Objects.equals(getCreatedAt(), comment.getCreatedAt());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getArticleId(), getContent(), getCreatedBy(), getCreatedAt());
+    }
+}

--- a/src/main/java/codesquad/springcafe/domain/comment/Comment.java
+++ b/src/main/java/codesquad/springcafe/domain/comment/Comment.java
@@ -9,6 +9,7 @@ public class Comment {
     private String content;
     private String createdBy;
     private LocalDateTime createdAt;
+    private boolean deleted = false;
 
     public Comment() {
     }
@@ -60,6 +61,25 @@ public class Comment {
 
     public boolean isSameAuthor(String author) {
         return createdBy.equals(author);
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public Comment setDeleted(boolean deleted) {
+        this.deleted = deleted;
+        return this;
+    }
+
+    public Comment restore() {
+        this.deleted = false;
+        return this;
+    }
+
+    public Comment softDelete() {
+        this.deleted = true;
+        return this;
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/domain/comment/Comment.java
+++ b/src/main/java/codesquad/springcafe/domain/comment/Comment.java
@@ -58,6 +58,10 @@ public class Comment {
         return this;
     }
 
+    public boolean isSameAuthor(String author) {
+        return createdBy.equals(author);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepository.java
@@ -16,5 +16,9 @@ public interface ArticleRepository {
 
     void delete(long id);
 
+    void softDelete(long id);
+
+    void restore(long id);
+
     void clear();
 }

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
@@ -82,7 +82,10 @@ public class ArticleRepositoryH2 implements ArticleRepository {
 
     @Override
     public void clear() {
-        String sql = "alter table if exists article drop constraint if exists fk_created_by; TRUNCATE TABLE ARTICLE; ALTER TABLE ARTICLE ALTER COLUMN ARTICLE_ID RESTART WITH 1";
+        String sql = "alter table if exists article drop constraint if exists fk_created_by;"
+                + "alter table if exists comment drop constraint if exists fk_comment_created_by;"
+                + "alter table if exists comment drop constraint if exists fk_comment_article_id;"
+                + "TRUNCATE TABLE ARTICLE; ALTER TABLE ARTICLE ALTER COLUMN ARTICLE_ID RESTART WITH 1";
         template.update(sql);
     }
 

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
@@ -55,7 +55,7 @@ public class ArticleRepositoryH2 implements ArticleRepository {
 
     @Override
     public Optional<Article> findById(long id) {
-        String sql = "select ARTICLE_ID, TITLE, CONTENTS, CREATED_BY, CREATED_AT, DELETED from ARTICLE where ARTICLE_ID = ?";
+        String sql = "select ARTICLE_ID, TITLE, CONTENTS, CREATED_BY, CREATED_AT, DELETED from ARTICLE where ARTICLE_ID = ? and DELETED is false";
         try {
             return Optional.ofNullable(template.queryForObject(sql, articleRowMapper(), id));
         } catch (EmptyResultDataAccessException e) {
@@ -65,7 +65,7 @@ public class ArticleRepositoryH2 implements ArticleRepository {
 
     @Override
     public List<Article> findAll() {
-        String sql = "select ARTICLE_ID, TITLE, CONTENTS, CREATED_BY, CREATED_AT, DELETED from ARTICLE where CREATED_AT >= dateadd(day, -3, current_date) order by CREATED_AT desc ";
+        String sql = "select ARTICLE_ID, TITLE, CONTENTS, CREATED_BY, CREATED_AT, DELETED from ARTICLE where DELETED is false and CREATED_AT >= dateadd(day, -3, current_date) order by CREATED_AT desc ";
         return template.query(sql, articleRowMapper());
     }
 

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -75,7 +76,7 @@ public class ArticleRepositoryH2 implements ArticleRepository {
     }
 
     @Override
-    public void delete(long id) {
+    public void delete(long id) throws DataIntegrityViolationException {
         String sql = "delete from ARTICLE where ARTICLE_ID = ?";
         template.update(sql, id);
     }

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryH2.java
@@ -30,7 +30,7 @@ public class ArticleRepositoryH2 implements ArticleRepository {
 
     @Override
     public Article save(Article article) {
-        String sql = "INSERT INTO ARTICLE(TITLE, CONTENTS, CREATED_BY, CREATED_AT, DELETED) VALUES(?, ?, ?, ?, ?)";
+        String sql = "INSERT INTO ARTICLE(TITLE, CONTENTS, CREATED_BY, CREATED_AT) VALUES(?, ?, ?, ?)";
 
         GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
 
@@ -40,7 +40,6 @@ public class ArticleRepositoryH2 implements ArticleRepository {
             ps.setString(2, article.getContents());
             ps.setString(3, article.getCreatedBy());
             ps.setTimestamp(4, Timestamp.valueOf(article.getCreatedAt()));
-            ps.setBoolean(5, article.isDeleted());
             return ps;
         }, keyHolder);
 

--- a/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryInMemory.java
+++ b/src/main/java/codesquad/springcafe/repository/article/ArticleRepositoryInMemory.java
@@ -53,6 +53,16 @@ public class ArticleRepositoryInMemory implements ArticleRepository {
     }
 
     @Override
+    public void softDelete(long id) {
+        store.values().forEach(Article::softDelete);
+    }
+
+    @Override
+    public void restore(long id) {
+        store.values().forEach(Article::restore);
+    }
+
+    @Override
     public void clear() {
         store.clear();
         sequence.set(0L);

--- a/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
@@ -18,6 +18,8 @@ public interface CommentRepository {
 
     void softDelete(long id);
 
+    void bulkSoftDelete(List<Long> commentIds);
+
     void restore(long id);
 
     void clear();

--- a/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
@@ -1,0 +1,20 @@
+package codesquad.springcafe.repository.comment;
+
+import codesquad.springcafe.controller.comment.CommentUpdateForm;
+import codesquad.springcafe.domain.comment.Comment;
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository {
+    Comment save(Comment comment);
+
+    Optional<Comment> findById(long id);
+
+    List<Comment> findAllByArticleId(long articleId);
+
+    void update(CommentUpdateForm updateParam);
+
+    void delete(long id);
+
+    void clear();
+}

--- a/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/comment/CommentRepository.java
@@ -16,5 +16,9 @@ public interface CommentRepository {
 
     void delete(long id);
 
+    void softDelete(long id);
+
+    void restore(long id);
+
     void clear();
 }

--- a/src/main/java/codesquad/springcafe/repository/comment/CommentRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/comment/CommentRepositoryH2.java
@@ -51,7 +51,7 @@ public class CommentRepositoryH2 implements CommentRepository {
 
     @Override
     public Optional<Comment> findById(long id) {
-        String sql = "SELECT COMMENT_ID, ARTICLE_ID, CONTENT, CREATED_BY, CREATED_AT FROM COMMENT WHERE COMMENT_ID = ?";
+        String sql = "SELECT COMMENT_ID, ARTICLE_ID, CONTENT, CREATED_BY, CREATED_AT, DELETED FROM COMMENT WHERE COMMENT_ID = ? and DELETED is false";
         try {
             return Optional.ofNullable(template.queryForObject(sql, replyRowMapper(), id));
         } catch (EmptyResultDataAccessException e) {
@@ -61,7 +61,7 @@ public class CommentRepositoryH2 implements CommentRepository {
 
     @Override
     public List<Comment> findAllByArticleId(long articleId) {
-        String sql = "SELECT COMMENT_ID, ARTICLE_ID, CONTENT, CREATED_BY, CREATED_AT FROM COMMENT WHERE ARTICLE_ID = ? ORDER BY CREATED_AT";
+        String sql = "SELECT COMMENT_ID, ARTICLE_ID, CONTENT, CREATED_BY, CREATED_AT, DELETED FROM COMMENT WHERE ARTICLE_ID = ? and DELETED is false ORDER BY CREATED_AT";
         return template.query(sql, replyRowMapper(), articleId);
     }
 
@@ -73,6 +73,7 @@ public class CommentRepositoryH2 implements CommentRepository {
             comment.setContent(rs.getString("content"));
             comment.setCreatedBy(rs.getString("created_by"));
             comment.setCreatedAt(rs.getTimestamp("created_at").toLocalDateTime());
+            comment.setDeleted(rs.getBoolean("deleted"));
             return comment;
         };
     }
@@ -87,6 +88,18 @@ public class CommentRepositoryH2 implements CommentRepository {
     public void delete(long id) {
         String sql = "delete from COMMENT where COMMENT_ID = ?";
         template.update(sql, id);
+    }
+
+    @Override
+    public void softDelete(long id) {
+        String sql = "update COMMENT set DELETED = ? where COMMENT_ID = ?";
+        template.update(sql, true, id);
+    }
+
+    @Override
+    public void restore(long id) {
+        String sql = "update COMMENT set DELETED = ? where COMMENT_ID = ?";
+        template.update(sql, false, id);
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/repository/comment/CommentRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/comment/CommentRepositoryH2.java
@@ -97,6 +97,15 @@ public class CommentRepositoryH2 implements CommentRepository {
     }
 
     @Override
+    public void bulkSoftDelete(List<Long> commentIds) {
+        String sql = "update COMMENT set DELETED = ? where COMMENT_ID = ?";
+        template.batchUpdate(sql, commentIds, commentIds.size(), (ps, commentId) -> {
+            ps.setBoolean(1, true);
+            ps.setLong(2, commentId);
+        });
+    }
+
+    @Override
     public void restore(long id) {
         String sql = "update COMMENT set DELETED = ? where COMMENT_ID = ?";
         template.update(sql, false, id);

--- a/src/main/java/codesquad/springcafe/repository/member/MemberRepositoryH2.java
+++ b/src/main/java/codesquad/springcafe/repository/member/MemberRepositoryH2.java
@@ -76,7 +76,10 @@ public class MemberRepositoryH2 implements MemberRepository {
 
     @Override
     public void clear() {
-        String sql = "alter table if exists ARTICLE drop constraint if exists fk_created_by; truncate table MEMBER; alter table MEMBER alter column MEMBER_ID restart with 1";
+        String sql = "alter table if exists article drop constraint if exists fk_created_by;"
+                + "alter table if exists comment drop constraint if exists fk_comment_created_by;"
+                + "alter table if exists comment drop constraint if exists fk_comment_article_id;"
+                + "truncate table MEMBER; alter table MEMBER alter column MEMBER_ID restart with 1";
         template.update(sql);
     }
 

--- a/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
+++ b/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
@@ -74,7 +74,11 @@ public class ArticleManager implements ArticleService {
         }
 
         /* 모든 댓글 먼저 삭제 */
-        comments.forEach(comment -> commentRepository.softDelete(comment.getId())); // TODO: bulk update 메서드 만들기
+        List<Long> commentIds = comments.stream()
+                .map(Comment::getId)
+                .toList();
+
+        commentRepository.bulkSoftDelete(commentIds);
 
         /* 삭제 트랜잭션 */
         try {

--- a/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
+++ b/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
@@ -74,11 +74,11 @@ public class ArticleManager implements ArticleService {
         }
 
         /* 모든 댓글 먼저 삭제 */
-        comments.forEach(comment -> commentRepository.delete(comment.getId())); // TODO: bulk update 메서드 만들기
+        comments.forEach(comment -> commentRepository.softDelete(comment.getId())); // TODO: bulk update 메서드 만들기
 
         /* 삭제 트랜잭션 */
         try {
-            articleRepository.delete(id);
+            articleRepository.softDelete(id);
         } catch (DataIntegrityViolationException e) {
             throw new DataDeletionException("데이터를 삭제 할 수 없습니다. 제약조건을 확인해야 합니다. 게시물 아이디: " + id, e);
         }

--- a/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
+++ b/src/main/java/codesquad/springcafe/service/article/ArticleManager.java
@@ -2,20 +2,26 @@ package codesquad.springcafe.service.article;
 
 import codesquad.springcafe.controller.article.UpdateArticle;
 import codesquad.springcafe.domain.article.Article;
+import codesquad.springcafe.domain.comment.Comment;
 import codesquad.springcafe.repository.article.ArticleRepository;
+import codesquad.springcafe.repository.comment.CommentRepository;
+import codesquad.springcafe.service.exception.DataDeletionException;
 import codesquad.springcafe.service.exception.ResourceNotFoundException;
 import codesquad.springcafe.service.exception.UnauthorizedException;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ArticleManager implements ArticleService {
     private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
 
     @Autowired
-    public ArticleManager(ArticleRepository articleRepository) {
+    public ArticleManager(ArticleRepository articleRepository, CommentRepository commentRepository) {
         this.articleRepository = articleRepository;
+        this.commentRepository = commentRepository;
     }
 
     @Override
@@ -51,6 +57,30 @@ public class ArticleManager implements ArticleService {
 
     @Override
     public void unpublish(long id) {
-        articleRepository.delete(id);
+        /* 게시물 작성자 확인 */
+        Article article = findArticle(id);
+        String author = article.getCreatedBy();
+
+        /* 해당 게시물의 댓글들 확인 */
+        List<Comment> comments = commentRepository.findAllByArticleId(id);
+
+        /* 모든 댓글 작성자가 게시물 작성자와 같은지 확인 */
+        boolean allMatch = comments.stream()
+                .allMatch(comment -> comment.isSameAuthor(author));
+
+        /* 모든 댓글 작성자가 게시물 작성자와 일치하지 않으면 예외 발생 */
+        if (!allMatch) {
+            throw new DataDeletionException("데이터를 삭제 할 수 없습니다. 제약조건을 확인해야 합니다. 게시물 아이디: " + id);
+        }
+
+        /* 모든 댓글 먼저 삭제 */
+        comments.forEach(comment -> commentRepository.delete(comment.getId())); // TODO: bulk update 메서드 만들기
+
+        /* 삭제 트랜잭션 */
+        try {
+            articleRepository.delete(id);
+        } catch (DataIntegrityViolationException e) {
+            throw new DataDeletionException("데이터를 삭제 할 수 없습니다. 제약조건을 확인해야 합니다. 게시물 아이디: " + id, e);
+        }
     }
 }

--- a/src/main/java/codesquad/springcafe/service/comment/CommentManager.java
+++ b/src/main/java/codesquad/springcafe/service/comment/CommentManager.java
@@ -45,7 +45,7 @@ public class CommentManager implements CommentService {
 
     @Override
     public void unpublish(long id) {
-        repository.delete(id);
+        repository.softDelete(id);
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/service/comment/CommentManager.java
+++ b/src/main/java/codesquad/springcafe/service/comment/CommentManager.java
@@ -1,0 +1,57 @@
+package codesquad.springcafe.service.comment;
+
+import codesquad.springcafe.controller.comment.CommentUpdateForm;
+import codesquad.springcafe.domain.comment.Comment;
+import codesquad.springcafe.repository.comment.CommentRepository;
+import codesquad.springcafe.service.exception.ResourceNotFoundException;
+import codesquad.springcafe.service.exception.UnauthorizedException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommentManager implements CommentService {
+
+    private final CommentRepository repository;
+
+    @Autowired
+    public CommentManager(CommentRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Comment publish(Comment comment) {
+        return repository.save(comment);
+    }
+
+    @Override
+    public Comment findComment(long commentId) {
+        return repository.findById(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 댓글을 찾을 수 없습니다. 댓글 아이디: " + commentId));
+    }
+
+    @Override
+    public List<Comment> findAllComment(long articleId) {
+        return repository.findAllByArticleId(articleId);
+    }
+
+    @Override
+    public void editComment(String loginId, CommentUpdateForm updateParam) {
+        /* 작성자 검증 */
+        validateAuthor(loginId, updateParam.getAuthor());
+
+        repository.update(updateParam);
+    }
+
+    @Override
+    public void unpublish(long id) {
+        repository.delete(id);
+    }
+
+    @Override
+    public void validateAuthor(String loginId, String author) {
+        if (!loginId.equals(author)) {
+            throw new UnauthorizedException("로그인한 아이디로 작성한 댓글이 아닙니다. 로그인 아이디: " + loginId);
+        }
+    }
+}

--- a/src/main/java/codesquad/springcafe/service/comment/CommentService.java
+++ b/src/main/java/codesquad/springcafe/service/comment/CommentService.java
@@ -1,0 +1,19 @@
+package codesquad.springcafe.service.comment;
+
+import codesquad.springcafe.controller.comment.CommentUpdateForm;
+import codesquad.springcafe.domain.comment.Comment;
+import java.util.List;
+
+public interface CommentService {
+    Comment publish(Comment comment);
+
+    Comment findComment(long commentId);
+
+    List<Comment> findAllComment(long articleId);
+
+    void editComment(String loginId, CommentUpdateForm updateParam);
+
+    void unpublish(long id);
+
+    void validateAuthor(String loginId, String author);
+}

--- a/src/main/java/codesquad/springcafe/service/exception/DataDeletionException.java
+++ b/src/main/java/codesquad/springcafe/service/exception/DataDeletionException.java
@@ -1,0 +1,24 @@
+package codesquad.springcafe.service.exception;
+
+public class DataDeletionException extends RuntimeException {
+    public DataDeletionException() {
+        super();
+    }
+
+    public DataDeletionException(String message) {
+        super(message);
+    }
+
+    public DataDeletionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataDeletionException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DataDeletionException(String message, Throwable cause, boolean enableSuppression,
+                                    boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,7 @@
 -- article 외래키 제약조건 먼저 제거
 alter table if exists article drop constraint if exists fk_created_by;
+alter table if exists comment drop constraint if exists fk_comment_created_by;
+alter table if exists comment drop constraint if exists fk_comment_article_id;
 
 -- member
 drop table if exists member;
@@ -22,4 +24,17 @@ create table article
     created_by varchar(255),
     created_at timestamp,
     constraint fk_created_by foreign key (created_by) references member(login_id) on delete cascade
+);
+
+-- comment
+drop table if exists comment;
+create table comment
+(
+    comment_id   bigint primary key auto_increment,
+    article_id bigint,
+    content   varchar(255),
+    created_by varchar(255),
+    created_at timestamp,
+    constraint fk_comment_created_by foreign key (created_by) references member(login_id),
+    constraint fk_comment_article_id foreign key (article_id) references article(article_id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -23,6 +23,7 @@ create table article
     contents   longvarchar,
     created_by varchar(255),
     created_at timestamp,
+    deleted boolean default false,
     constraint fk_created_by foreign key (created_by) references member(login_id) on delete cascade
 );
 
@@ -35,6 +36,7 @@ create table comment
     content   varchar(255),
     created_by varchar(255),
     created_at timestamp,
+    deleted boolean default false,
     constraint fk_comment_created_by foreign key (created_by) references member(login_id),
     constraint fk_comment_article_id foreign key (article_id) references article(article_id) on delete restrict
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -36,5 +36,5 @@ create table comment
     created_by varchar(255),
     created_at timestamp,
     constraint fk_comment_created_by foreign key (created_by) references member(login_id),
-    constraint fk_comment_article_id foreign key (article_id) references article(article_id)
+    constraint fk_comment_article_id foreign key (article_id) references article(article_id) on delete restrict
 );

--- a/src/main/resources/templates/error/delete-failed.html
+++ b/src/main/resources/templates/error/delete-failed.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta charset="utf-8">
+    <title>게시물을 삭제할 수 없습니다.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <link href="../css/bootstrap.min.css" th:href="@{/css/bootstrap.min.css}" rel="stylesheet">
+    <!--[if lt IE 9]>
+    <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <link href="../css/styles.css" th:href="@{/css/styles.css}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-fixed-top header">
+    <div class="col-md-12">
+        <div class="navbar-header">
+
+            <a href="../home.html" th:href="@{/}" class="navbar-brand">Yelly's Spring Cafe</a>
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse1">
+                <i class="glyphicon glyphicon-search"></i>
+            </button>
+
+        </div>
+        <div class="collapse navbar-collapse" id="navbar-collapse1">
+            <form class="navbar-form pull-left">
+                <div class="input-group" style="max-width:470px;">
+                    <input type="text" class="form-control" placeholder="Search" name="srch-term" id="srch-term">
+                    <div class="input-group-btn">
+                        <button class="btn btn-default btn-primary" type="submit"><i
+                                class="glyphicon glyphicon-search"></i></button>
+                    </div>
+                </div>
+            </form>
+            <ul class="nav navbar-nav navbar-right">
+                <li>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="glyphicon glyphicon-bell"></i></a>
+                    <ul class="dropdown-menu">
+                        <li><a href="/" target="_blank">Yelly's Spring Cafe</a></li>
+                        <li><a href="https://github.com/Yeriimii" target="_blank">Yelly's GitHub</a></li>
+                    </ul>
+                </li>
+                <li><a href="../members/list.html" th:href="@{/members/list}"><i
+                        class="glyphicon glyphicon-user"></i></a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div class="container" id="main">
+    <div class="row text-center">
+        <div>
+            <h1>죄송합니다, 게시물을 삭제할 수 없습니다.</h1>
+            <p>요청하신 게시물 삭제를 할 수 없습니다. 아마도 게시물에 댓글이 존재해 이런 상황이 발생했을 것으로 추정됩니다.</p>
+            <p>다음 몇 가지 방법을 시도해 볼 수 있습니다:</p>
+            <ul class="list-group text-center">
+                <li class="list-inline">게시물에 댓글이 없는지 확인해 주세요. 댓글이 있으면 삭제할 수 없습니다.</li>
+                <li class="list-inline">이전 페이지로 돌아가서 다른 링크를 시도해 보세요.</li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+<!-- script references -->
+<script src="../js/jquery-2.2.0.min.js" th:src="@{/js/jquery-2.2.0.min.js}"></script>
+<script src="../js/bootstrap.min.js" th:src="@{/js/bootstrap.min.js}"></script>
+<script src="../js/scripts.js" th:src="@{/js/scripts.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/fragment/comment/commentsFragment.html
+++ b/src/main/resources/templates/fragment/comment/commentsFragment.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="kr">
+
+<th:block th:fragment="commentList (comments, lineSeparator)">
+    <article th:each="comment, commentStat : ${comments}" class="article" id="answer-1405">
+        <div class="article-header">
+            <div class="article-header-thumb">
+                <img src="https://graph.facebook.com/v2.3/1324855987/picture"
+                     class="article-author-thumb" alt="">
+            </div>
+            <div class="article-header-text">
+                <a th:href="@{|/members/${comment.createdBy}|}" class="article-author-name">
+                    <span th:text="${comment.createdBy}"></span>
+                </a>
+                <div class="article-header-time">
+                    <span th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2016-01-12 14:06</span>
+                    <i class="icon-link"></i>
+                </div>
+            </div>
+        </div>
+        <div class="article-doc comment-doc">
+            <p th:utext="${#strings.replace(comment.content, lineSeparator, '&lt;br /&gt;')}">이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+        </div>
+        <div class="article-util">
+            <ul class="article-util-list">
+                <li>
+                    <a class="link-modify-article" th:href="@{|/questions/${articleId}/comments/${comment.id}/edit|}">
+                        수정
+                    </a>
+                </li>
+                <li>
+                    <form class="delete-answer-form" th:action="@{|/questions/${articleId}/comments/${comment.id}|}"
+                          th:method="delete" method="post">
+                        <button type="submit" class="delete-answer-button">삭제</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </article>
+</th:block>
+</html>

--- a/src/main/resources/templates/fragment/comment/commentsFragment.html
+++ b/src/main/resources/templates/fragment/comment/commentsFragment.html
@@ -23,6 +23,7 @@
         </div>
         <div class="article-util">
             <ul class="article-util-list">
+                <th:block th:if="${loginMember == comment.createdBy}">
                 <li>
                     <a class="link-modify-article" th:href="@{|/questions/${articleId}/comments/${comment.id}/edit|}">
                         수정
@@ -34,6 +35,7 @@
                         <button type="submit" class="delete-answer-button">삭제</button>
                     </form>
                 </li>
+                </th:block>
             </ul>
         </div>
     </article>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -29,7 +29,7 @@
                             </div>
                             <div class="reply" title="댓글">
                                 <i class="icon-reply"></i>
-                                <span class="point">0</span>
+                                <span class="point" th:text="*{article.commentSize}">0</span>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/qna/commentUpdateForm.html
+++ b/src/main/resources/templates/qna/commentUpdateForm.html
@@ -25,9 +25,7 @@
                     </textarea>
                     <div class="field-error" th:errors="*{content}" />
                 </div>
-                <button type="submit" class="btn btn-success clearfix pull-right">
-                    게시물 수정
-                </button>
+                <button type="submit" class="btn btn-success clearfix pull-right">수정</button>
                 <div class="clearfix"/>
             </form>
         </div>

--- a/src/main/resources/templates/qna/commentUpdateForm.html
+++ b/src/main/resources/templates/qna/commentUpdateForm.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="kr">
+<head th:replace="~{fragment/layout/header :: header(~{::title})}">
+    <title>Update Your Article</title>
+</head>
+
+<body th:replace="~{fragment/layout/content :: content(~{::contentBody})}">
+<div th:fragment="contentBody" class="container" id="main">
+    <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
+        <div class="panel panel-default content-main">
+            <form th:action="@{|/questions/*{articleId}/comments/*{id}|}" action="" th:object="${form}" method="post" th:method="put">
+                <div th:if="${#fields.hasGlobalErrors()}">
+                    <p class="field-error" th:each="err : ${#fields.globalErrors()}"
+                       th:text="${err}">오류 메시지</p>
+                </div>
+                <div class="form-group">
+                    <label for="comment-id">댓글 번호</label>
+                    <input class="form-control" id="comment-id" name="comment-id" th:field="*{id}" placeholder="댓글 번호" readonly/>
+                    <input hidden="hidden" th:field="*{articleId}" readonly>
+                    <input hidden="hidden" th:field="*{author}" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="content">댓글 내용</label>
+                    <textarea id="content" name="content" class="form-control" rows="5" th:field="*{content}" placeholder="내용">
+                    </textarea>
+                    <div class="field-error" th:errors="*{content}" />
+                </div>
+                <button type="submit" class="btn btn-success clearfix pull-right">
+                    게시물 수정
+                </button>
+                <div class="clearfix"/>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/qna/detail.html
+++ b/src/main/resources/templates/qna/detail.html
@@ -9,7 +9,8 @@
     <div class="col-md-12 col-sm-12 col-lg-12">
         <div class="panel panel-default" th:object="${article}">
             <header class="qna-header">
-                <h2 class="qna-title" th:text="*{title}">InitializingBean implements afterPropertiesSet() 호출되지 않는 문제.</h2>
+                <h2 class="qna-title" th:text="*{title}">InitializingBean implements afterPropertiesSet() 호출되지 않는
+                    문제.</h2>
             </header>
             <div class="content-main">
                 <article class="article">
@@ -19,7 +20,8 @@
                                  class="article-author-thumb" alt="">
                         </div>
                         <div class="article-header-text">
-                            <a href="/users/92/kimmunsu" th:href="@{|/members/*{createdBy}|}" class="article-author-name">
+                            <a href="/users/92/kimmunsu" th:href="@{|/members/*{createdBy}|}"
+                               class="article-author-name">
                                 <span th:text="*{createdBy}">guest</span>
                             </a>
                             <div class="article-header-time">
@@ -49,78 +51,17 @@
 
                 <div class="qna-comment">
                     <div class="qna-comment-slipp">
-                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                        <p class="qna-comment-count"><strong th:text="${comments.size()}">0</strong>개의 의견</p>
                         <div class="qna-comment-slipp-articles">
-
-                            <article class="article" id="answer-1405">
-                                <div class="article-header">
-                                    <div class="article-header-thumb">
-                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
-                                             class="article-author-thumb" alt="">
-                                    </div>
-                                    <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            2016-01-12 14:06
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="article-doc comment-doc">
-                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                                </div>
-                                <div class="article-util">
-                                    <ul class="article-util-list">
-                                        <li>
-                                            <a class="link-modify-article"
-                                               href="/questions/413/answers/1405/form">수정</a>
-                                        </li>
-                                        <li>
-                                            <form class="delete-answer-form" action="/questions/413/answers/1405"
-                                                  method="POST">
-                                                <input type="hidden" name="_method" value="DELETE">
-                                                <button type="submit" class="delete-answer-button">삭제</button>
-                                            </form>
-                                        </li>
-                                    </ul>
-                                </div>
+                            <article th:replace="~{fragment/comment/commentsFragment :: commentList(${comments}, ${lineSeparator})}" class="article" id="answer-1405">
                             </article>
-                            <article class="article" id="answer-1406">
-                                <div class="article-header">
-                                    <div class="article-header-thumb">
-                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
-                                             class="article-author-thumb" alt="">
-                                    </div>
-                                    <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            2016-01-12 14:06
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="article-doc comment-doc">
-                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                                </div>
-                                <div class="article-util">
-                                    <ul class="article-util-list">
-                                        <li>
-                                            <a class="link-modify-article"
-                                               href="/questions/413/answers/1405/form">수정</a>
-                                        </li>
-                                        <li>
-                                            <form class="form-delete" action="/questions/413/answers/1405"
-                                                  method="POST">
-                                                <input type="hidden" name="_method" value="DELETE">
-                                                <button type="submit" class="delete-answer-button">삭제</button>
-                                            </form>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </article>
-                            <form class="submit-write">
+                            <form class="submit-write" th:action="@{|/questions/${article.id}/comments|}"
+                                  th:object="${commentForm}" method="POST">
                                 <div class="form-group" style="padding:14px;">
-                                    <textarea class="form-control" placeholder="Update your status"></textarea>
+                                    <textarea class="form-control" th:field="${commentForm.content}" placeholder="의견을 나눠 보세요"></textarea>
                                 </div>
-                                <button class="btn btn-success pull-right" type="button">답변하기</button>
+                                <div class="field-error" th:errors="*{content}" />
+                                <button class="btn btn-success pull-right" type="submit">답변하기</button>
                                 <div class="clearfix"/>
                             </form>
                         </div>
@@ -130,35 +71,5 @@
         </div>
     </div>
 </div>
-
-<script type="text/template" id="answerTemplate">
-    <article class="article">
-        <div class="article-header">
-            <div class="article-header-thumb">
-                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-            </div>
-            <div class="article-header-text">
-                <a href="#" class="article-author-name">{0}</a>
-                <div class="article-header-time">{1}</div>
-            </div>
-        </div>
-        <div class="article-doc comment-doc">
-            {2}
-        </div>
-        <div class="article-util">
-            <ul class="article-util-list">
-                <li>
-                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
-                </li>
-                <li>
-                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-                        <input type="hidden" name="_method" value="DELETE">
-                        <button type="submit" class="delete-answer-button">삭제</button>
-                    </form>
-                </li>
-            </ul>
-        </div>
-    </article>
-</script>
 </body>
 </html>

--- a/src/main/resources/templates/qna/detail.html
+++ b/src/main/resources/templates/qna/detail.html
@@ -39,6 +39,7 @@
                                 <a class="link-modify-article"
                                    href="/questions/423/form" th:href="@{|/questions/*{id}/edit|}">수정</a>
                             </li>
+                            </th:block>
                             <li>
                                 <a class="link-modify-article" th:href="@{|/questions/*{id}/delete|}">삭제</a>
                             </li>

--- a/src/test/java/codesquad/springcafe/controller/comment/CommentUpdateFormTest.java
+++ b/src/test/java/codesquad/springcafe/controller/comment/CommentUpdateFormTest.java
@@ -1,0 +1,74 @@
+package codesquad.springcafe.controller.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import codesquad.springcafe.controller.article.UpdateArticle;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class CommentUpdateFormTest {
+
+    @Autowired
+    private Validator validator;
+
+    @DisplayName("게시물 번호, 작성자, 제목, 본문 내용 모두 값이 있으면 검증에 통과된다")
+    @Test
+    void validate_success() {
+        // given
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(1L);
+        form.setArticleId(1L);
+        form.setContent("test title");
+
+        // when
+        Set<ConstraintViolation<CommentUpdateForm>> violations = validator.validate(form);
+
+        Iterator<ConstraintViolation<CommentUpdateForm>> iterator = violations.iterator();
+
+        List<String> message = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            ConstraintViolation<CommentUpdateForm> next = iterator.next();
+            message.add(next.getMessage());
+        }
+
+        // then
+        assertThat(message).isEmpty();
+    }
+
+    @DisplayName("내용이 비어있으면 검증에 실패하고 에러 메시지가 추가된다")
+    @Test
+    void validate_fail_when_empty_title() {
+        // given
+        /* 제목이 없는 경우 */
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(1L);
+        form.setArticleId(1L);
+
+        // when
+        Set<ConstraintViolation<CommentUpdateForm>> violations = validator.validate(form);
+
+        Iterator<ConstraintViolation<CommentUpdateForm>> iterator = violations.iterator();
+
+        List<String> message = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            ConstraintViolation<CommentUpdateForm> next = iterator.next();
+            message.add(next.getMessage());
+        }
+
+        // then
+        assertThat(message).contains("비어 있을 수 없습니다");
+    }
+}

--- a/src/test/java/codesquad/springcafe/controller/comment/CommentUpdateFormTest.java
+++ b/src/test/java/codesquad/springcafe/controller/comment/CommentUpdateFormTest.java
@@ -29,6 +29,7 @@ class CommentUpdateFormTest {
         CommentUpdateForm form = new CommentUpdateForm();
         form.setId(1L);
         form.setArticleId(1L);
+        form.setAuthor("tester1");
         form.setContent("test title");
 
         // when
@@ -55,6 +56,33 @@ class CommentUpdateFormTest {
         CommentUpdateForm form = new CommentUpdateForm();
         form.setId(1L);
         form.setArticleId(1L);
+        form.setAuthor("tester1");
+
+        // when
+        Set<ConstraintViolation<CommentUpdateForm>> violations = validator.validate(form);
+
+        Iterator<ConstraintViolation<CommentUpdateForm>> iterator = violations.iterator();
+
+        List<String> message = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            ConstraintViolation<CommentUpdateForm> next = iterator.next();
+            message.add(next.getMessage());
+        }
+
+        // then
+        assertThat(message).contains("비어 있을 수 없습니다");
+    }
+
+    @DisplayName("작성자가 비어있으면 검증에 실패하고 에러 메시지가 추가된다")
+    @Test
+    void validate_fail_when_empty_author() {
+        // given
+        /* 작성자가 없는 경우 */
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(1L);
+        form.setArticleId(1L);
+        form.setContent("test title");
 
         // when
         Set<ConstraintViolation<CommentUpdateForm>> violations = validator.validate(form);

--- a/src/test/java/codesquad/springcafe/domain/article/ArticleTest.java
+++ b/src/test/java/codesquad/springcafe/domain/article/ArticleTest.java
@@ -22,6 +22,7 @@ class ArticleTest {
         assertThat(article.getTitle()).isEqualTo("test");
         assertThat(article.getCreatedBy()).isEqualTo("guest");
         assertThat(article.getContents()).isEqualTo("test body");
+        assertThat(article.isDeleted()).isFalse();
     }
 
     @DisplayName("같은 제목, 작성자, 본문 내용, 작성시간 이더라도 발급된 id가 다르면 다른 게시물이다")
@@ -50,5 +51,31 @@ class ArticleTest {
 
         // then
         assertThat(article1).isNotEqualTo(article2);
+    }
+
+    @DisplayName("게시글에 대해 soft delete 를 할 수 있다")
+    @Test
+    void softDelete() {
+        // given
+        Article article = new Article();
+
+        // when
+        article.softDelete();
+
+        // then
+        assertThat(article.isDeleted()).isTrue();
+    }
+
+    @DisplayName("게시글에 대해 삭제 상태를 복원할 수 있다")
+    @Test
+    void restore() {
+        // given
+        Article article = new Article();
+
+        // when
+        article.restore();
+
+        // then
+        assertThat(article.isDeleted()).isFalse();
     }
 }

--- a/src/test/java/codesquad/springcafe/domain/comment/CommentTest.java
+++ b/src/test/java/codesquad/springcafe/domain/comment/CommentTest.java
@@ -26,5 +26,33 @@ class CommentTest {
         assertThat(comment.getArticleId()).isEqualTo(1L);
         assertThat(comment.getContent()).isEqualTo("댓글 테스트");
         assertThat(comment.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(comment.isDeleted()).isFalse();
+    }
+
+    @DisplayName("댓글에 대해 soft delete 를 할 수 있다")
+    @Test
+    void softDelete() {
+        // given
+        Comment comment = new Comment();
+
+        // when
+        comment.softDelete();
+
+        // then
+        assertThat(comment.isDeleted()).isTrue();
+    }
+
+    @DisplayName("댓글에 대해 삭제 상태를 복원할 수 있다")
+    @Test
+    void restore() {
+        // given
+        Comment comment = new Comment();
+        comment.softDelete();
+
+        // when
+        comment.restore();
+
+        // then
+        assertThat(comment.isDeleted()).isFalse();
     }
 }

--- a/src/test/java/codesquad/springcafe/domain/comment/CommentTest.java
+++ b/src/test/java/codesquad/springcafe/domain/comment/CommentTest.java
@@ -1,0 +1,30 @@
+package codesquad.springcafe.domain.comment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CommentTest {
+
+    @DisplayName("yelly 아이디를 가진 멤버는 첫 번째 게시물에 댓글을 만들 수 있다")
+    @Test
+    void create_comment() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.now();
+        Comment comment = new Comment();
+
+        // when
+        comment.setArticleId(1L);
+        comment.setCreatedBy("yelly");
+        comment.setContent("댓글 테스트");
+        comment.setCreatedAt(createdAt);
+
+        // then
+        assertThat(comment.getCreatedBy()).isEqualTo("yelly");
+        assertThat(comment.getArticleId()).isEqualTo(1L);
+        assertThat(comment.getContent()).isEqualTo("댓글 테스트");
+        assertThat(comment.getCreatedAt()).isEqualTo(createdAt);
+    }
+}

--- a/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryH2Test.java
@@ -136,4 +136,45 @@ class ArticleRepositoryH2Test {
         assertThat(findArticle.getCreatedBy()).isEqualTo("yelly");
         assertThat(findArticle.getContents()).isEqualTo("success contents");
     }
+
+    @DisplayName("게시물을 soft delete 하면 deleted 상태가 true 가 된다")
+    @Test
+    void softDelete() {
+        // given
+        Article article = new Article();
+        article.setTitle("test");
+        article.setContents("test body");
+        article.setCreatedBy("yelly");
+        article.setCreatedAt(LocalDateTime.parse("2024-04-12T00:00:00"));
+
+        repository.save(article);
+
+        // when
+        repository.softDelete(1L);
+        Article findArticle = repository.findById(1L).get();
+
+        // then
+        assertThat(findArticle.isDeleted()).isTrue();
+    }
+
+    @DisplayName("delete 상태인 게시물을 복원하면 deleted 상태가 false 가 된다")
+    @Test
+    void restore() {
+        // given
+        Article article = new Article();
+        article.setTitle("test");
+        article.setContents("test body");
+        article.setCreatedBy("yelly");
+        article.setCreatedAt(LocalDateTime.parse("2024-04-12T00:00:00"));
+        article.softDelete();
+
+        repository.save(article);
+
+        // when
+        repository.restore(1L);
+        Article findArticle = repository.findById(1L).get();
+
+        // then
+        assertThat(findArticle.isDeleted()).isFalse();
+    }
 }

--- a/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryH2Test.java
@@ -137,7 +137,7 @@ class ArticleRepositoryH2Test {
         assertThat(findArticle.getContents()).isEqualTo("success contents");
     }
 
-    @DisplayName("게시물을 soft delete 하면 deleted 상태가 true 가 된다")
+    @DisplayName("게시물을 soft delete 하면 deleted 상태가 true 가 되어 조회되지 않는다")
     @Test
     void softDelete() {
         // given
@@ -151,10 +151,10 @@ class ArticleRepositoryH2Test {
 
         // when
         repository.softDelete(1L);
-        Article findArticle = repository.findById(1L).get();
+        Optional<Article> optionalArticle = repository.findById(1L);
 
         // then
-        assertThat(findArticle.isDeleted()).isTrue();
+        assertThat(optionalArticle).isEmpty();
     }
 
     @DisplayName("delete 상태인 게시물을 복원하면 deleted 상태가 false 가 된다")

--- a/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryInMemoryTest.java
+++ b/src/test/java/codesquad/springcafe/repository/article/ArticleRepositoryInMemoryTest.java
@@ -143,4 +143,45 @@ class ArticleRepositoryInMemoryTest {
         assertThat(findArticle.getCreatedBy()).isEqualTo("guest");
         assertThat(findArticle.getContents()).isEqualTo("success contents");
     }
+
+    @DisplayName("게시물을 soft delete 하면 deleted 상태가 true 가 된다")
+    @Test
+    void softDelete() {
+        // given
+        Article article = new Article();
+        article.setTitle("test");
+        article.setContents("test body");
+        article.setCreatedBy("yelly");
+        article.setCreatedAt(LocalDateTime.parse("2024-04-12T00:00:00"));
+
+        articleRepository.save(article);
+
+        // when
+        articleRepository.softDelete(1L);
+        Article findArticle = articleRepository.findById(1L).get();
+
+        // then
+        assertThat(findArticle.isDeleted()).isTrue();
+    }
+
+    @DisplayName("delete 상태인 게시물을 복원하면 deleted 상태가 false 가 된다")
+    @Test
+    void restore() {
+        // given
+        Article article = new Article();
+        article.setTitle("test");
+        article.setContents("test body");
+        article.setCreatedBy("yelly");
+        article.setCreatedAt(LocalDateTime.parse("2024-04-12T00:00:00"));
+        article.softDelete();
+
+        articleRepository.save(article);
+
+        // when
+        articleRepository.restore(1L);
+        Article findArticle = articleRepository.findById(1L).get();
+
+        // then
+        assertThat(findArticle.isDeleted()).isFalse();
+    }
 }

--- a/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
@@ -156,4 +156,45 @@ class CommentRepositoryH2Test {
         // then
         assertThat(comments).hasSize(0);
     }
+
+    @DisplayName("게시물을 soft delete 하면 deleted 상태가 true 가 되어 조회되지 않는다")
+    @Test
+    void softDelete() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        commentRepository.save(comment);
+
+        // when
+        commentRepository.softDelete(1L);
+        Optional<Comment> optionalComment = commentRepository.findById(1L);
+
+        // then
+        assertThat(optionalComment).isEmpty();
+    }
+
+    @DisplayName("delete 상태인 게시물을 복원하면 deleted 상태가 false 가 된다")
+    @Test
+    void restore() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+        comment.softDelete();
+
+        commentRepository.save(comment);
+
+        // when
+        commentRepository.restore(1L);
+        Comment findComment = commentRepository.findById(1L).get();
+
+        // then
+        assertThat(findComment.isDeleted()).isFalse();
+    }
 }

--- a/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
@@ -1,0 +1,158 @@
+package codesquad.springcafe.repository.comment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import codesquad.springcafe.controller.comment.CommentUpdateForm;
+import codesquad.springcafe.domain.article.Article;
+import codesquad.springcafe.domain.comment.Comment;
+import codesquad.springcafe.domain.member.Member;
+import codesquad.springcafe.repository.article.ArticleRepositoryH2;
+import codesquad.springcafe.repository.member.MemberRepositoryH2;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@JdbcTest
+@Import(CommentRepositoryH2.class)
+class CommentRepositoryH2Test {
+
+    public static final LocalDateTime NOW = LocalDateTime.now();
+
+    @Autowired
+    private CommentRepositoryH2 commentRepository;
+
+    @SpyBean
+    private MemberRepositoryH2 memberRepository;
+
+    @SpyBean
+    private ArticleRepositoryH2 articleRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.save(new Member("yelly", "123", null, null));
+        articleRepository.save(new Article().setCreatedBy("yelly").setCreatedAt(NOW));
+    }
+
+    @AfterEach
+    void reset_pk() {
+        memberRepository.clear();
+        articleRepository.clear();
+    }
+
+    @DisplayName("yelly 아이디를 가진 멤버가 1번 게시물에 대한 댓글을 작성할 수 있다")
+    @Test
+    void save() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        // when
+        Comment savedComment = commentRepository.save(comment);
+
+        // then
+        assertThat(savedComment.getArticleId()).isEqualTo(1L);
+        assertThat(savedComment.getCreatedBy()).isEqualTo("yelly");
+        assertThat(savedComment.getContent()).isEqualTo("테스트 댓글");
+        assertThat(savedComment.getCreatedAt()).isEqualTo(NOW);
+    }
+
+    @DisplayName("멤버 아이디 yelly로 1번 게시물에 대한 댓글을 작성할 수 있다")
+    @Test
+    void findById() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        commentRepository.save(comment);
+
+        // when
+        Optional<Comment> findComment = commentRepository.findById(1L);
+
+        // then
+        assertThat(findComment).isPresent();
+        assertThat(findComment.get()).extracting("articleId").isEqualTo(1L);
+        assertThat(findComment.get()).extracting("createdBy").isEqualTo("yelly");
+        assertThat(findComment.get()).extracting("content").isEqualTo("테스트 댓글");
+    }
+
+    @DisplayName("1번 게시물에 대한 모든 댓글 2개를 찾을 수 있다")
+    @Test
+    void findAllByArticleId() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        commentRepository.save(comment);
+        commentRepository.save(comment);
+
+        // when
+        List<Comment> comments = commentRepository.findAllByArticleId(1L);
+
+        // then
+        assertThat(comments).hasSize(2);
+        assertThat(comments).extracting("content").contains("테스트 댓글", "테스트 댓글");
+    }
+
+    @DisplayName("'테스트 댓글'이라는 댓글을 '변경 후 댓글'이라는 내용으로 변경할 수 있다")
+    @Test
+    void update() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        Comment savedComment = commentRepository.save(comment);
+
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(savedComment.getId());
+        form.setContent("변경 후 댓글");
+
+        // when
+        commentRepository.update(form);
+        Comment updatedComment = commentRepository.findById(savedComment.getId()).get();
+
+        // then
+        assertThat(updatedComment.getContent()).isEqualTo("변경 후 댓글");
+    }
+
+    @DisplayName("1번 게시물에 대한 댓글 1개를 삭제할 수 있다")
+    @Test
+    void delete() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        commentRepository.save(comment);
+
+        // when
+        commentRepository.delete(1L);
+        List<Comment> comments = commentRepository.findAllByArticleId(1L);
+
+        // then
+        assertThat(comments).hasSize(0);
+    }
+}

--- a/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
@@ -11,6 +11,7 @@ import codesquad.springcafe.repository.member.MemberRepositoryH2;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -196,5 +197,29 @@ class CommentRepositoryH2Test {
 
         // then
         assertThat(findComment.isDeleted()).isFalse();
+    }
+
+    @DisplayName("아아디 1번 부터 10번까지 벌크 연산으로 삭제할 수 있다")
+    @Test
+    void bulkSoftDelete() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setContent("테스트 댓글");
+        comment.setCreatedBy("yelly");
+        comment.setCreatedAt(NOW);
+
+        for (int i = 0; i < 10; i++) {
+            commentRepository.save(comment);
+        }
+
+        List<Long> commentIds = LongStream.rangeClosed(1L, 10L).boxed().toList();
+
+        // when
+        commentRepository.bulkSoftDelete(commentIds);
+        List<Comment> comments = commentRepository.findAllByArticleId(1L);
+
+        // then
+        assertThat(comments).hasSize(0);
     }
 }

--- a/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
+++ b/src/test/java/codesquad/springcafe/repository/comment/CommentRepositoryH2Test.java
@@ -47,6 +47,7 @@ class CommentRepositoryH2Test {
     void reset_pk() {
         memberRepository.clear();
         articleRepository.clear();
+        commentRepository.clear();
     }
 
     @DisplayName("yelly 아이디를 가진 멤버가 1번 게시물에 대한 댓글을 작성할 수 있다")

--- a/src/test/java/codesquad/springcafe/service/comment/CommentServiceTest.java
+++ b/src/test/java/codesquad/springcafe/service/comment/CommentServiceTest.java
@@ -1,0 +1,233 @@
+package codesquad.springcafe.service.comment;
+
+import static org.assertj.core.api.Assertions.*;
+
+import codesquad.springcafe.controller.comment.CommentUpdateForm;
+import codesquad.springcafe.domain.article.Article;
+import codesquad.springcafe.domain.comment.Comment;
+import codesquad.springcafe.domain.member.Member;
+import codesquad.springcafe.repository.article.ArticleRepository;
+import codesquad.springcafe.repository.comment.CommentRepository;
+import codesquad.springcafe.repository.member.MemberRepository;
+import codesquad.springcafe.service.exception.ResourceNotFoundException;
+import codesquad.springcafe.service.exception.UnauthorizedException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class CommentServiceTest {
+    public static final LocalDateTime NOW = LocalDateTime.now();
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @BeforeEach
+    void setUp() {
+        /* 테스터1, 테스터2 생성 */
+        memberRepository.save(new Member("tester1", null, null, null));
+        memberRepository.save(new Member("tester2", null, null, null));
+
+        /* 게시물 생성 */
+        Article article1 = makeArticle("test1", "tester1", "body1", NOW);
+        Article article2 = makeArticle("test2", "tester2", "body2", NOW.minusDays(2));
+        articleRepository.save(article1);
+        articleRepository.save(article2);
+    }
+
+    @BeforeEach
+    void clear() {
+        memberRepository.clear();
+        articleRepository.clear();
+        commentRepository.clear();
+    }
+
+    @DisplayName("1번 게시물에 tester1 아이디를 가진 멤버가 '테스트 댓글'이라는 내용의 댓글을 게시할 수 있다")
+    @Test
+    void publish() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        // when
+        Comment publishedComment = commentService.publish(comment);
+
+        // then
+        assertThat(publishedComment.getContent()).isEqualTo("테스트 댓글");
+        assertThat(publishedComment.getCreatedBy()).isEqualTo("tester1");
+        assertThat(publishedComment.getCreatedAt()).isEqualTo(NOW);
+    }
+
+    @DisplayName("1번 게시물에 작성한 '테스트 댓글' 이라는 내용의 댓글을 찾을 수 있다")
+    @Test
+    void findComment_success() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        commentService.publish(comment);
+
+        // when
+        Comment findComment = commentService.findComment(1L);
+
+        // then
+        assertThat(findComment.getContent()).isEqualTo("테스트 댓글");
+        assertThat(findComment.getCreatedBy()).isEqualTo("tester1");
+        assertThat(findComment.getCreatedAt()).isEqualTo(NOW);
+    }
+
+    @DisplayName("2번 게시물에 작성한 댓글을 찾을 수 없으면 ResourceNotFoundException 예외를 던진다")
+    @Test
+    void findComment_fail() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        commentService.publish(comment);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.findComment(2L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @DisplayName("1번 게시물에 대한 모든 댓글 5개를 찾을 수 있다")
+    @Test
+    void findAllComment() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        for (int i = 0; i < 5; i++) {
+            commentService.publish(comment);
+        }
+
+        // when
+        List<Comment> comments = commentService.findAllComment(1L);
+
+        // then
+        assertThat(comments).hasSize(5);
+        assertThat(comments).extracting("content")
+                .contains("테스트 댓글", "테스트 댓글", "테스트 댓글", "테스트 댓글", "테스트 댓글");
+    }
+
+    @DisplayName("tester1 멤버가 작성한 댓글을 tester2 멤버가 수정 시도 시 UnauthorizedException 예외를 던진다")
+    @Test
+    void validateAuthor() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        commentService.publish(comment);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.validateAuthor("tester2", "tester1"))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @DisplayName("tester1 멤버가 작성한 '테스트 댓글' 내용의 댓글을 동일 멤버가 '변경 후 댓글'로 수정할 수 있다")
+    @Test
+    void editComment_success() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        Comment publishedComment = commentService.publish(comment);
+
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(publishedComment.getId());
+        form.setAuthor("tester1");
+        form.setContent("변경 후 댓글");
+
+        // when
+        commentService.editComment("tester1", form);
+        Comment updatedComment = commentService.findComment(1L);
+
+        // then
+        assertThat(updatedComment.getContent()).isEqualTo("변경 후 댓글");
+    }
+
+    @DisplayName("tester1 멤버가 작성한 댓글을 tester2 멤버가 수정 시도 시 UnauthorizedException 예외를 던진다")
+    @Test
+    void editComment_fail() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        Comment publishedComment = commentService.publish(comment);
+
+        CommentUpdateForm form = new CommentUpdateForm();
+        form.setId(publishedComment.getId());
+        form.setAuthor("tester1");
+        form.setContent("변경 후 댓글");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.editComment("tester2", form))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @DisplayName("댓글 아이디 1번에 대해 삭제할 수 있다")
+    @Test
+    void unpublish() {
+        // given
+        Comment comment = new Comment();
+        comment.setArticleId(1L);
+        comment.setCreatedBy("tester1");
+        comment.setContent("테스트 댓글");
+        comment.setCreatedAt(NOW);
+
+        commentService.publish(comment);
+
+        // when
+        commentService.unpublish(1L);
+
+        // then
+        assertThatThrownBy(() -> commentService.findComment(1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    private Article makeArticle(String title, String createdBy, String contents, LocalDateTime createdAt) {
+        Article article = new Article();
+        article.setTitle(title);
+        article.setCreatedBy(createdBy);
+        article.setContents(contents);
+        article.setCreatedAt(createdAt);
+
+        return article;
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 배포 주소: [사이트 접속 링크](http://3.34.50.77:8080/)

- 메시지 컨벤션

| url | 기능 |
| --- | --- |
| GET /:articleId/comments/:commentId/edit | 댓글 수정 폼 |
| PUT /:articleId/comments/:commentId | 댓글 수정 요청 |
| DELETE /:articleId/comments/:commentId | 댓글 삭제 요청 |

- 댓글 조회 기능
  - 홈 화면의 게시글 목록에서 게시물의 댓글 개수를 확인할 수 있습니다
  - 로그인한 사용자만 게시글 상세보기 화면에서 댓글을 조회할 수 있습니다
- 댓글 수정 및 삭제 기능
  - 로그인한 사용자만 자신의 댓글을 수정 및 삭제할 수 있습니다
  - 로그인한 사용자의 댓글일때만 수정과 삭제 버튼이 보입니다
  - 로그인한 사용자가 아닌 사용자가 수정, 삭제를 시도할 때 403 에러 페이지로 이동합니다
- 게시글, 댓글의 Soft Delete 기능
  - 게시글과 댓글의 삭제 요청 시 데이터베이스에서 삭제되지 않는 대신 deleted 컬럼의 값을 false로 업데이트 합니다
  - soft delete 된 게시물과 댓글을 복원할 수 있는 기능을 구현했습니다
- 게시글 삭제 기능 변경
  - 게시글 삭제 시 게시글의 "모든 댓글의 작성자"가 "게시글 작성자"와 일치하면 soft delete 됩니다
  - 만약 한 개의 댓글이라도 일치하지 않으면 Http Status Code는 500이며, "삭제 불가 에러 화면"을 보여줍니다

## 고민 사항
### 게시글 목록 조회 화면(홈 화면)에서 게시글에 달린 댓글의 개수를 보여줄 때 고민했던 부분입니다
- Article 과 Comment는 1:N 관계이지만, 이는 데이터베이스 상에서만 FK로 관계가 형성되어있고, 코드 상에는 연관관계가 표현되어있지 않습니다
- 만약 Article 내부에 필드로 `List<Comment>` 를 갖는다면 게시글 목록 뷰에서 해당 리스트의 크기를 나타내는 식으로 표현할 수 있으며, 연관관계에 대해 더 명확한 표현이 가능해집니다
- 그러나 저는 필드로 `int commentSize`를 갖도록 했습니다
#### List<Comment> 대신 int commentSize 선택한 이유:
- `게시글에 달린 댓글의 개수`가 필요한 경우는 "홈 화면"과 "상세 화면" 두 곳뿐입니다
  - `게시글에 달린 댓글의 개수`는 현재 "홈 화면"과 "상세 화면" 두 곳에서만 필요합니다
  - 만약 `List<Comment>` 로 연관관계를 표현하면 Article을 조회하는 쿼리가 `2`번 나가야 합니다. Article 테이블 조회 후 Comment 테이블을 조회해야 하기 때문입니다.
  - 반면에 `int commentSize`로 통계 수치만 표현하면 Article을 조회하는 쿼리가 `1`번만 나가면 됩니다. (LEFT JOIN 사용)
  - 현재 단계에서 이 부분에 대해 @honux77 는 어떻게 생각하시는지 궁금합니다.

## 기타
- 게시글을 soft delete 하는 부분에 bulk update 로 처리했습니다
  - "모든 댓글의 작성자"가 "게시글 작성자"와 일치하면 모든 댓글의 ID를 리스트로 전달해서 한 번의 쿼리로 모든 댓글들이 soft delete 되도록 구현했습니다

## 트러블 슈팅
- 댓글이 없는 게시물이 조회되지 않는 문제

### 원인: SQL 구문 실수
```sql
-- 문제의 쿼리
SELECT A.ARTICLE_ID, A.TITLE, A.CREATED_BY, A.CREATED_AT,COUNT(C.COMMENT_ID) as comment_size
FROM ARTICLE A LEFT JOIN COMMENT C ON A.ARTICLE_ID = C.ARTICLE_ID AND C.DELETED = false
WHERE A.DELETED is false and A.CREATED_AT >= dateadd(day, -3, current_date)
ORDER BY A.CREATED_AT desc;
```

- `GROUP BY`로 누락으로 인한 실수
  - 집계 함수에 사용된 컬럼(C.DELETED) 이외의 컬럼들은 `group by`에 포함시켜 그룹 별로 어떤 값을 가져야하는지 명시해야 함.
- `COALESCE` 누락으로 인한 실수
  - 댓글이 없는 게시물은 LEFT JOIN 으로 매칭이 안되기 때문에 `COUNT` 함수 특성 상 `null`로 처리됨.
  - 하지만 콘솔에서 쿼리 실행 시 comment_size는 `0`으로 정상 출력

### 해결 방법
-`GROUP BY`로 누락으로 인한 실수: `GROUP BY A.ARTICLE_ID, A.TITLE, A.CREATED_BY, A.CREATED_AT` 으로 명시.
-`COALESCE` 누락으로 인한 실수: `COALESCE` 함수로 `COUNT`를 감싸서 `null`에 대한 기본 값을 지정.

```sql
-- 수정 후 쿼리
SELECT A.ARTICLE_ID, A.TITLE, A.CREATED_BY, A.CREATED_AT, COALESCE(COUNT(C.COMMENT_ID), 0) as comment_size
FROM ARTICLE A LEFT JOIN COMMENT C ON A.ARTICLE_ID = C.ARTICLE_ID AND C.DELETED = false
WHERE A.DELETED is false and A.CREATED_AT >= dateadd(day, -3, current_date)
GROUP BY A.ARTICLE_ID, A.TITLE, A.CREATED_BY, A.CREATED_AT
ORDER BY A.CREATED_AT desc;
```

## 작동 예시
### 게시글 목록의 댓글 개수 조회
![spring-cafe-article-list-comment-size2](https://github.com/codesquad-members-2024/be-spring-cafe/assets/87357932/ef895f5f-5283-4689-9c3c-17a8ee75e81f)

### 댓글 수정 전 (로그인 한 아이디: yelly)
![spring-cafe-comment-edit-before](https://github.com/codesquad-members-2024/be-spring-cafe/assets/87357932/26c91029-76bd-4fb0-811a-329b51c7f682)

### 댓글 수정 폼 (로그인 한 아이디: yelly)
![spring-cafe-comment-edit-form](https://github.com/codesquad-members-2024/be-spring-cafe/assets/87357932/cc4fc9f6-d0c5-43b5-9684-cd2e95d1805a)

### 댓글 폼 검증 (빈 값 검증)
![spring-cafe-comment-edit-validate](https://github.com/codesquad-members-2024/be-spring-cafe/assets/87357932/51f8da9d-401c-4916-8030-007f3e027ffa)

### 댓글 수정 후 (로그인 한 아이디: yelly)
![spring-cafe-comment-edit-after](https://github.com/codesquad-members-2024/be-spring-cafe/assets/87357932/e9999e3c-e0d5-4ed7-9f5c-eb083f33eb08)
