### PR TITLE
[코리] Step-5 게시글 권한부여

### DIFF
--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -3,6 +3,7 @@ package codesquad.springcafe.controller;
 import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
 import codesquad.springcafe.repository.ArticleRepository;
+import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.*;
 @Controller
 @RequestMapping("/question")
 public class ArticleController {
+
+    public static final String LOGIN_USER_ID = "loginUserId";
 
     private final Logger log = LoggerFactory.getLogger(ArticleController.class);
     private final ArticleRepository articleRepository;
@@ -26,8 +29,9 @@ public class ArticleController {
     }
 
     @PostMapping
-    public String writeQuestion(@ModelAttribute ArticleRequestDto articleRequestDto) {
-        Article article = new Article(articleRequestDto);
+    public String writeQuestion(@ModelAttribute ArticleRequestDto articleRequestDto, HttpSession session) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        Article article = new Article(userId, articleRequestDto);
         articleRepository.save(article);
         return "redirect:/";
     }

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.controller;
 
 import codesquad.springcafe.dto.ArticleRequestDto;
+import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.model.Article;
 import codesquad.springcafe.service.ArticleService;
 import jakarta.servlet.http.HttpSession;
@@ -50,11 +51,12 @@ public class ArticleController {
     public String getArticleUpdateForm(@PathVariable Long articleId, HttpSession session, Model model) {
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
         if (articleService.checkArticleWriter(articleId, userId)) {
+            log.debug("게시물 수정 성공 {}", userId);
             model.addAttribute(ARTICLE_ID, articleId);
             return "qna/update_form";
         }
-        model.addAttribute("errorMessage", "본인의 게시글만 수정할 수 있습니다.");
-        return "errors/error";
+        log.debug("게시물 수정 실패 {}", userId);
+        throw new UnauthorizedAccessException("본인의 게시글만 수정할 수 있습니다.");
     }
 
     @PutMapping("{articleId}")
@@ -64,13 +66,14 @@ public class ArticleController {
     }
 
     @DeleteMapping("{articleId}")
-    public String deleteArticle(@PathVariable Long articleId, HttpSession session, Model model) {
+    public String deleteArticle(@PathVariable Long articleId, HttpSession session){
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
         if (articleService.checkArticleWriter(articleId, userId)) {
+            log.debug("게시물 삭제 성공 {}", userId);
             articleService.delete(articleId);
             return "redirect:/";
         }
-        model.addAttribute("errorMessage", "본인의 게시글만 삭제할 수 있습니다.");
-        return "errors/error";
+        log.debug("게시물 삭제 실패 {}", userId);
+        throw new UnauthorizedAccessException("본인의 게시글만 삭제할 수 있습니다.");
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -53,7 +53,8 @@ public class ArticleController {
             model.addAttribute(ARTICLE_ID, articleId);
             return "qna/update_form";
         }
-        return "errors/update_error";
+        model.addAttribute("errorMessage", "본인의 게시글만 수정할 수 있습니다.");
+        return "errors/error";
     }
 
     @PutMapping("{articleId}")

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -2,7 +2,7 @@ package codesquad.springcafe.controller;
 
 import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
-import codesquad.springcafe.repository.ArticleRepository;
+import codesquad.springcafe.service.ArticleService;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,12 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public class ArticleController {
 
     public static final String LOGIN_USER_ID = "loginUserId";
+    public static final String ARTICLE_ID = "articleId";
 
     private final Logger log = LoggerFactory.getLogger(ArticleController.class);
-    private final ArticleRepository articleRepository;
+    private final ArticleService articleService;
 
-    public ArticleController(ArticleRepository articleRepository) {
-        this.articleRepository = articleRepository;
+
+    public ArticleController(ArticleService articleService) {
+        this.articleService = articleService;
     }
 
     @GetMapping
@@ -32,15 +34,31 @@ public class ArticleController {
     public String writeQuestion(@ModelAttribute ArticleRequestDto articleRequestDto, HttpSession session) {
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
         Article article = new Article(userId, articleRequestDto);
-        articleRepository.save(article);
+        articleService.createArticle(article);
         return "redirect:/";
     }
 
     @GetMapping("/{articleId}")
     public String getArticle(@PathVariable Long articleId, Model model) {
-        Article article = articleRepository.findById(articleId);
+        Article article = articleService.findById(articleId);
         log.debug("getArticle : {}", article);
         model.addAttribute("article", article);
         return "qna/show";
+    }
+
+    @GetMapping("/update/{articleId}")
+    public String getArticleUpdateForm(@PathVariable Long articleId, HttpSession session, Model model) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        if (articleService.checkArticleWriter(articleId, userId)) {
+            model.addAttribute(ARTICLE_ID, articleId);
+            return "qna/update_form";
+        }
+        return "errors/update_error";
+    }
+
+    @PutMapping("{articleId}")
+    public String updateArticle(@PathVariable Long articleId, @ModelAttribute ArticleRequestDto articleRequestDto) {
+        articleService.update(articleId, articleRequestDto);
+        return "redirect:/question/" + articleId;
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -62,4 +62,15 @@ public class ArticleController {
         articleService.update(articleId, articleRequestDto);
         return "redirect:/question/" + articleId;
     }
+
+    @DeleteMapping("{articleId}")
+    public String deleteArticle(@PathVariable Long articleId, HttpSession session, Model model) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        if (articleService.checkArticleWriter(articleId, userId)) {
+            articleService.delete(articleId);
+            return "redirect:/";
+        }
+        model.addAttribute("errorMessage", "본인의 게시글만 삭제할 수 있습니다.");
+        return "errors/error";
+    }
 }

--- a/src/main/java/codesquad/springcafe/controller/ErrorController.java
+++ b/src/main/java/codesquad/springcafe/controller/ErrorController.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.controller;
 
 import codesquad.springcafe.exception.ArticleNotFountException;
+import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.exception.UserNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,7 +10,7 @@ import org.springframework.web.servlet.ModelAndView;
 @ControllerAdvice
 public class ErrorController {
 
-    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class})
+    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class, UnauthorizedAccessException.class})
     public ModelAndView handleException(Exception e) {
         ModelAndView model = new ModelAndView("errors/error");
         model.addObject("errorMessage", e.getMessage());

--- a/src/main/java/codesquad/springcafe/controller/ErrorController.java
+++ b/src/main/java/codesquad/springcafe/controller/ErrorController.java
@@ -1,0 +1,19 @@
+package codesquad.springcafe.controller;
+
+import codesquad.springcafe.exception.ArticleNotFountException;
+import codesquad.springcafe.exception.UserNotFoundException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.ModelAndView;
+
+@ControllerAdvice
+public class ErrorController {
+
+    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class})
+    public ModelAndView handleException(Exception e) {
+        ModelAndView model = new ModelAndView("errors/error");
+        model.addObject("errorMessage", e.getMessage());
+        return model;
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -73,7 +73,7 @@ public class UserController {
         return "user/form";
     }
 
-    @GetMapping("/{userId}/form")
+    @GetMapping("update/{userId}")
     public String getUserUpdateForm(@PathVariable String userId, Model model) {
         model.addAttribute("userId", userId);
         return "user/updateForm";

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -2,6 +2,7 @@ package codesquad.springcafe.controller;
 
 import codesquad.springcafe.dto.UserProfileDto;
 import codesquad.springcafe.dto.UserUpdateDto;
+import codesquad.springcafe.model.UpdateUser;
 import codesquad.springcafe.model.User;
 import codesquad.springcafe.service.UserService;
 import jakarta.servlet.http.HttpSession;
@@ -79,19 +80,19 @@ public class UserController {
     }
 
     @PutMapping("/{userId}")
-    public String updateUser(@PathVariable String userId, @RequestParam("password") String password, @RequestParam("newPassword") String newPassword, @RequestParam("name") String name, @RequestParam("email") String email, HttpSession httpSession) {
+    public String updateUser(@PathVariable String userId, @ModelAttribute UserUpdateDto userUpdateDto, HttpSession httpSession) {
         String loginUserId = (String) httpSession.getAttribute(LOGIN_USER_ID);
         if (!loginUserId.equals(userId)) {
             return "redirect:/";
         }
-        UserUpdateDto userUpdateDto = new UserUpdateDto(userId, password, newPassword, name, email);
+        UpdateUser updateUser = userUpdateDto.toEntity(userId);
         try {
-            userService.update(userUpdateDto);
+            userService.update(updateUser);
         } catch (IllegalArgumentException e) {
-            log.debug("user {} password does not match", userUpdateDto.getUserId());
+            log.debug("user {} password does not match", loginUserId);
             return "redirect:/users/" + userId + "/form";
         }
-        log.debug("user {} update", userUpdateDto.getUserId());
+        log.debug("user {} update", loginUserId);
         return "redirect:/users";
     }
 

--- a/src/main/java/codesquad/springcafe/controller/UserController.java
+++ b/src/main/java/codesquad/springcafe/controller/UserController.java
@@ -59,11 +59,16 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public String login(@RequestParam String userId, @RequestParam String password, HttpSession httpSession) {
+    public String login(
+            @RequestParam String userId,
+            @RequestParam String password,
+            @RequestParam(defaultValue = "/") String redirectUri,
+            HttpSession httpSession) {
+
         if (userService.isValidUser(userId, password)) {
             httpSession.setAttribute(LOGIN_USER_ID, userId);
             log.debug("로그인 성공: {}", userId);
-            return "redirect:/";
+            return "redirect:" + redirectUri;
         }
         return "redirect:/users/login";
     }

--- a/src/main/java/codesquad/springcafe/dto/ArticleRequestDto.java
+++ b/src/main/java/codesquad/springcafe/dto/ArticleRequestDto.java
@@ -2,18 +2,12 @@ package codesquad.springcafe.dto;
 
 public class ArticleRequestDto {
 
-    private final String writer;
     private final String title;
     private final String contents;
 
-    public ArticleRequestDto(String writer, String title, String contents) {
-        this.writer = writer;
+    public ArticleRequestDto(String title, String contents) {
         this.title = title;
         this.contents = contents;
-    }
-
-    public String getWriter() {
-        return writer;
     }
 
     public String getTitle() {

--- a/src/main/java/codesquad/springcafe/dto/UserUpdateDto.java
+++ b/src/main/java/codesquad/springcafe/dto/UserUpdateDto.java
@@ -1,23 +1,19 @@
 package codesquad.springcafe.dto;
 
+import codesquad.springcafe.model.UpdateUser;
+
 public class UserUpdateDto {
 
-    private final String userId;
     private final String password;
     private final String newPassword;
     private final String name;
     private final String email;
 
-    public UserUpdateDto(String userId, String password, String newPassword, String name, String email) {
-        this.userId = userId;
+    public UserUpdateDto(String password, String newPassword, String name, String email) {
         this.password = password;
         this.newPassword = newPassword;
         this.name = name;
         this.email = email;
-    }
-
-    public String getUserId() {
-        return userId;
     }
 
     public String getPassword() {
@@ -36,14 +32,18 @@ public class UserUpdateDto {
         return email;
     }
 
+    public UpdateUser toEntity(String userId) {
+        return new UpdateUser(userId, password, newPassword, name, email);
+    }
+
     @Override
     public String toString() {
         return "UserUpdateDto{" +
-                "userId='" + userId + '\'' +
-                ", password='" + password + '\'' +
+                "password='" + password + '\'' +
                 ", newPassword='" + newPassword + '\'' +
                 ", name='" + name + '\'' +
                 ", email='" + email + '\'' +
                 '}';
     }
+
 }

--- a/src/main/java/codesquad/springcafe/exception/ArticleNotFountException.java
+++ b/src/main/java/codesquad/springcafe/exception/ArticleNotFountException.java
@@ -1,0 +1,9 @@
+package codesquad.springcafe.exception;
+
+public class ArticleNotFountException extends RuntimeException {
+
+    public ArticleNotFountException() {
+        super("해당 게시글이 존재하지 않습니다.");
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/exception/UnauthorizedAccessException.java
+++ b/src/main/java/codesquad/springcafe/exception/UnauthorizedAccessException.java
@@ -1,0 +1,9 @@
+package codesquad.springcafe.exception;
+
+public class UnauthorizedAccessException extends RuntimeException {
+
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/exception/UserNotFoundException.java
+++ b/src/main/java/codesquad/springcafe/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package codesquad.springcafe.exception;
+
+public class UserNotFoundException extends RuntimeException {
+
+    public UserNotFoundException(String userId) {
+        super("ID가 " + userId + "인 사용자가 존재하지 않습니다.");
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
@@ -14,7 +14,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         String requestURI = request.getRequestURI();
         HttpSession session = request.getSession(false);
         if (session == null || session.getAttribute(LOGIN_USER_ID) == null) {
-            response.sendRedirect("/users/login?redirectURL=" + requestURI);
+            response.sendRedirect("/users/login?redirectUri=" + requestURI);
             return false;
         }
         return true;

--- a/src/main/java/codesquad/springcafe/model/Article.java
+++ b/src/main/java/codesquad/springcafe/model/Article.java
@@ -73,4 +73,8 @@ public class Article {
         this.articleId = articleId;
     }
 
+    public boolean checkWriter(String userId) {
+        return this.writer.equals(userId);
+    }
+
 }

--- a/src/main/java/codesquad/springcafe/model/Article.java
+++ b/src/main/java/codesquad/springcafe/model/Article.java
@@ -33,12 +33,12 @@ public class Article {
         this.hits = new AtomicLong();
     }
 
-    public Article(long articleId, ArticleRequestDto articleRequestDto) {
-        this(articleId, articleRequestDto.getWriter(), articleRequestDto.getTitle(), articleRequestDto.getContents());
+    public Article(long articleId, String writer, ArticleRequestDto articleRequestDto) {
+        this(articleId, writer, articleRequestDto.getTitle(), articleRequestDto.getContents());
     }
 
-    public Article(ArticleRequestDto articleRequestDto) {
-        this.writer = articleRequestDto.getWriter();
+    public Article(String writer, ArticleRequestDto articleRequestDto) {
+        this.writer = writer;
         this.title = articleRequestDto.getTitle();
         this.contents = articleRequestDto.getContents();
         this.localDateTime = LocalDateTime.now();

--- a/src/main/java/codesquad/springcafe/model/UpdateUser.java
+++ b/src/main/java/codesquad/springcafe/model/UpdateUser.java
@@ -1,0 +1,37 @@
+package codesquad.springcafe.model;
+
+public class UpdateUser {
+    private final String userId;
+    private final String password;
+    private final String newPassword;
+    private final String name;
+    private final String email;
+
+    public UpdateUser(String userId, String password, String newPassword, String name, String email) {
+        this.userId = userId;
+        this.password = password;
+        this.newPassword = newPassword;
+        this.name = name;
+        this.email = email;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/codesquad/springcafe/model/User.java
+++ b/src/main/java/codesquad/springcafe/model/User.java
@@ -44,13 +44,13 @@ public class User {
                 '}';
     }
 
-    public void update(UserUpdateDto userUpdateDto) {
-        if (!validatePassword(userUpdateDto.getPassword())) {
+    public void update(UpdateUser updateUser) {
+        if (!validatePassword(updateUser.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
-        this.name = userUpdateDto.getName();
-        this.password = userUpdateDto.getNewPassword();
-        this.email = userUpdateDto.getEmail();
+        this.name = updateUser.getName();
+        this.password = updateUser.getNewPassword();
+        this.email = updateUser.getEmail();
     }
 
     public boolean validatePassword(String password) {

--- a/src/main/java/codesquad/springcafe/model/User.java
+++ b/src/main/java/codesquad/springcafe/model/User.java
@@ -1,7 +1,5 @@
 package codesquad.springcafe.model;
 
-import codesquad.springcafe.dto.UserUpdateDto;
-
 public class User {
 
     private String userId;

--- a/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.repository;
 
+import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -56,6 +57,12 @@ public class ArticleJdbcRepository implements ArticleRepository {
     public void clear() {
         String sql = "DELETE FROM articles";
         jdbcTemplate.update(sql);
+    }
+
+    @Override
+    public void update(Long articleId, ArticleRequestDto articleRequestDto) {
+        String sql = "UPDATE articles SET title = ?, contents = ? WHERE article_id = ?";
+        jdbcTemplate.update(sql, articleRequestDto.getTitle(), articleRequestDto.getContents(), articleId);
     }
 
     private RowMapper<Article> articleRowMapper() {

--- a/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
@@ -65,6 +65,12 @@ public class ArticleJdbcRepository implements ArticleRepository {
         jdbcTemplate.update(sql, articleRequestDto.getTitle(), articleRequestDto.getContents(), articleId);
     }
 
+    @Override
+    public void delete(Long articleId) {
+        String sql = "DELETE FROM articles WHERE article_id = ?";
+        jdbcTemplate.update(sql, articleId);
+    }
+
     private RowMapper<Article> articleRowMapper() {
         return (rs, rowNum) -> {
             long articleId = rs.getLong("article_id");

--- a/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
@@ -1,8 +1,10 @@
 package codesquad.springcafe.repository;
 
 import codesquad.springcafe.dto.ArticleRequestDto;
+import codesquad.springcafe.exception.ArticleNotFountException;
 import codesquad.springcafe.model.Article;
 import org.springframework.context.annotation.Primary;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
@@ -12,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Repository
 @Primary
@@ -42,9 +45,14 @@ public class ArticleJdbcRepository implements ArticleRepository {
     }
 
     @Override
-    public Article findById(Long articleId) {
+    public Optional<Article> findById(Long articleId) {
         String sql = "SELECT article_id, writer, title, contents, local_date_time, hits FROM articles WHERE article_id = ?";
-        return jdbcTemplate.queryForObject(sql, articleRowMapper(), articleId);
+        try {
+            Article article = jdbcTemplate.queryForObject(sql, articleRowMapper(), articleId);
+            return Optional.ofNullable(article);
+        } catch (EmptyResultDataAccessException e) {
+            throw new ArticleNotFountException();
+        }
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -23,8 +24,8 @@ public class ArticleMemoryRepository implements ArticleRepository {
         return articleId;
     }
 
-    public Article findById(Long articleId) {
-        return articles.get(articleId);
+    public Optional<Article> findById(Long articleId) {
+        return Optional.ofNullable(articles.get(articleId));
     }
 
     public List<Article> findAllArticle() {

--- a/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
@@ -39,4 +39,10 @@ public class ArticleMemoryRepository implements ArticleRepository {
     @Override
     public void update(Long articleId, ArticleRequestDto articleRequestDto) {
     }
+
+    @Override
+    public void delete(Long articleId) {
+        articles.remove(articleId);
+    }
+
 }

--- a/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleMemoryRepository.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.repository;
 
+import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
 import org.springframework.stereotype.Repository;
 
@@ -33,5 +34,9 @@ public class ArticleMemoryRepository implements ArticleRepository {
     public void clear() {
         articles.clear();
         sequence.set(0L);
+    }
+
+    @Override
+    public void update(Long articleId, ArticleRequestDto articleRequestDto) {
     }
 }

--- a/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
@@ -4,16 +4,17 @@ import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ArticleRepository {
 
     Long save(Article article);
 
-    Article findById(Long articleId);
+    Optional<Article> findById(Long articleId);
 
     List<Article> findAllArticle();
 
-    public void clear();
+    void clear();
 
     void update(Long articleId, ArticleRequestDto articleRequestDto);
 

--- a/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
@@ -16,4 +16,6 @@ public interface ArticleRepository {
     public void clear();
 
     void update(Long articleId, ArticleRequestDto articleRequestDto);
+
+    void delete(Long articleId);
 }

--- a/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleRepository.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.repository;
 
+import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.model.Article;
 
 import java.util.List;
@@ -13,4 +14,6 @@ public interface ArticleRepository {
     List<Article> findAllArticle();
 
     public void clear();
+
+    void update(Long articleId, ArticleRequestDto articleRequestDto);
 }

--- a/src/main/java/codesquad/springcafe/repository/UserJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/UserJdbcRepository.java
@@ -1,12 +1,15 @@
 package codesquad.springcafe.repository;
 
+import codesquad.springcafe.exception.UserNotFoundException;
 import codesquad.springcafe.model.User;
 import org.springframework.context.annotation.Primary;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @Primary
@@ -31,9 +34,14 @@ public class UserJdbcRepository implements UserRepository {
     }
 
     @Override
-    public User findUserById(String userId) {
+    public Optional<User> findUserById(String userId) {
         String sql = "SELECT * FROM users WHERE user_id = ?";
-        return jdbcTemplate.queryForObject(sql, userRowMapper(), userId);
+        try {
+            User user = jdbcTemplate.queryForObject(sql, userRowMapper(), userId);
+            return Optional.ofNullable(user);
+        } catch (EmptyResultDataAccessException e) {
+            throw new UserNotFoundException(userId);
+        }
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/repository/UserMemoryRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/UserMemoryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -25,8 +26,8 @@ public class UserMemoryRepository implements UserRepository {
         return new ArrayList<User>(users.values());
     }
 
-    public User findUserById(String userId) {
-        return users.get(userId);
+    public Optional<User> findUserById(String userId) {
+        return Optional.ofNullable(users.get(userId));
     }
 
     public void clear() {

--- a/src/main/java/codesquad/springcafe/repository/UserRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/UserRepository.java
@@ -3,6 +3,7 @@ package codesquad.springcafe.repository;
 import codesquad.springcafe.model.User;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository {
 
@@ -10,7 +11,7 @@ public interface UserRepository {
 
     List<User> findAllUsers();
 
-    User findUserById(String userId);
+    Optional<User> findUserById(String userId);
 
     void clear();
 

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -1,0 +1,34 @@
+package codesquad.springcafe.service;
+
+import codesquad.springcafe.dto.ArticleRequestDto;
+import codesquad.springcafe.model.Article;
+import codesquad.springcafe.repository.ArticleRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public ArticleService(ArticleRepository articleRepository) {
+        this.articleRepository = articleRepository;
+    }
+
+
+    public void createArticle(Article article) {
+        articleRepository.save(article);
+    }
+
+    public Article findById(Long articleId) {
+        return articleRepository.findById(articleId);
+    }
+
+    public boolean checkArticleWriter(Long articleId, String userId) {
+        Article article = articleRepository.findById(articleId);
+        return article.checkWriter(userId);
+    }
+
+    public void update(Long articleId, ArticleRequestDto articleRequestDto) {
+        articleRepository.update(articleId, articleRequestDto);
+    }
+}

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -31,4 +31,8 @@ public class ArticleService {
     public void update(Long articleId, ArticleRequestDto articleRequestDto) {
         articleRepository.update(articleId, articleRequestDto);
     }
+
+    public void delete(Long articleId) {
+        articleRepository.delete(articleId);
+    }
 }

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -1,9 +1,12 @@
 package codesquad.springcafe.service;
 
 import codesquad.springcafe.dto.ArticleRequestDto;
+import codesquad.springcafe.exception.ArticleNotFountException;
 import codesquad.springcafe.model.Article;
 import codesquad.springcafe.repository.ArticleRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class ArticleService {
@@ -20,11 +23,15 @@ public class ArticleService {
     }
 
     public Article findById(Long articleId) {
-        return articleRepository.findById(articleId);
+        Optional<Article> optionalArticle = articleRepository.findById(articleId);
+        if (optionalArticle.isPresent()) {
+            return optionalArticle.get();
+        }
+        throw new ArticleNotFountException();
     }
 
     public boolean checkArticleWriter(Long articleId, String userId) {
-        Article article = articleRepository.findById(articleId);
+        Article article = findById(articleId);
         return article.checkWriter(userId);
     }
 

--- a/src/main/java/codesquad/springcafe/service/UserService.java
+++ b/src/main/java/codesquad/springcafe/service/UserService.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.service;
 
 import codesquad.springcafe.dto.UserUpdateDto;
+import codesquad.springcafe.model.UpdateUser;
 import codesquad.springcafe.repository.UserRepository;
 import codesquad.springcafe.model.User;
 import org.springframework.stereotype.Service;
@@ -28,10 +29,10 @@ public class UserService {
         return userRepository.findUserById(userId);
     }
 
-    public void update(UserUpdateDto userUpdateDto) {
-        String userId = userUpdateDto.getUserId();
+    public void update(UpdateUser updateUser) {
+        String userId = updateUser.getUserId();
         User user = userRepository.findUserById(userId);
-        user.update(userUpdateDto);
+        user.update(updateUser);
         userRepository.update(user);
     }
 

--- a/src/main/java/codesquad/springcafe/service/UserService.java
+++ b/src/main/java/codesquad/springcafe/service/UserService.java
@@ -1,12 +1,13 @@
 package codesquad.springcafe.service;
 
-import codesquad.springcafe.dto.UserUpdateDto;
+import codesquad.springcafe.exception.UserNotFoundException;
 import codesquad.springcafe.model.UpdateUser;
-import codesquad.springcafe.repository.UserRepository;
 import codesquad.springcafe.model.User;
+import codesquad.springcafe.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class UserService {
@@ -26,18 +27,22 @@ public class UserService {
     }
 
     public User findUserById(String userId) {
-        return userRepository.findUserById(userId);
+        Optional<User> optionalUser = userRepository.findUserById(userId);
+        if (optionalUser.isPresent()) {
+            return optionalUser.get();
+        }
+        throw new UserNotFoundException(userId);
     }
 
     public void update(UpdateUser updateUser) {
         String userId = updateUser.getUserId();
-        User user = userRepository.findUserById(userId);
+        User user = findUserById(userId);
         user.update(updateUser);
         userRepository.update(user);
     }
 
     public boolean isValidUser(String userId, String password) {
-        User user = userRepository.findUserById(userId);
+        User user = findUserById(userId);
         return user.validatePassword(password);
     }
 

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -207,3 +207,7 @@ h3,h4,h5 {
     border: none;
 }
 
+.error-message {
+    font-size: large;
+    color: #dd1111;
+}

--- a/src/main/resources/templates/errors/error.html
+++ b/src/main/resources/templates/errors/error.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="kr" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/base.html::head}">
+</head>
+
+<body>
+<nav th:replace="~{fragments/base.html::navigation-bar}">
+</nav>
+
+<div class="navbar navbar-default" id="subnav" th:replace="~{fragments/base.html::subnav}">
+</div>
+
+<div class="container" id="main">
+        <div class="col-md-6 col-md-offset-3">
+                <div class="panel panel-default content-main">
+                        <p th:text="${errorMessage}" class="error-message">error message</p>
+                </div>
+        </div>
+</div>
+
+<!-- script references -->
+<div th:replace="~{fragments/base.html::scripts}">
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/base.html
+++ b/src/main/resources/templates/fragments/base.html
@@ -73,7 +73,7 @@
                     </form>
 <!--                    <a href="/users/logout" methods="POST" role="button">로그아웃</a>-->
                 </li>
-                <li th:if="${session.loginUserId != null}"><a th:href="@{/users/{userId}/form(userId = ${session.loginUserId})}" role="button">개인정보수정</a></li>
+                <li th:if="${session.loginUserId != null}"><a th:href="@{/users/update/{userId}(userId = ${session.loginUserId})}" role="button">개인정보수정</a></li>
             </ul>
         </div>
     </div>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -14,7 +14,7 @@
 <div class="container" id="main">
    <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
       <div class="panel panel-default qna-list">
-          <ul class="list" th:each="article : ${articles}">
+          <ul class="list" th:each="article : ${articles.reversed()}">
               <li>
                   <div class="wrap">
                       <div class="main">

--- a/src/main/resources/templates/qna/form.html
+++ b/src/main/resources/templates/qna/form.html
@@ -15,10 +15,6 @@
       <div class="panel panel-default content-main">
           <form name="question" method="post" action="/question">
               <div class="form-group">
-                  <label for="writer">글쓴이</label>
-                  <input class="form-control" id="writer" name="writer" placeholder="글쓴이"/>
-              </div>
-              <div class="form-group">
                   <label for="title">제목</label>
                   <input type="text" class="form-control" id="title" name="title" placeholder="제목"/>
               </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -36,10 +36,10 @@
                   <div class="article-util">
                       <ul class="article-util-list">
                           <li>
-                              <a class="link-modify-article" th:href="@{/questions/update/{articleId}(articleId = ${article.articleId})}">수정</a>
+                              <a class="link-modify-article" th:href="@{/question/update/{articleId}(articleId = ${article.articleId})}">수정</a>
                           </li>
                           <li>
-                              <form class="form-delete" th:action="@{/questions/{articleId}(articleId=${article.articleId})}" th:method="DELETE">
+                              <form class="form-delete" th:action="@{/question/{articleId}(articleId=${article.articleId})}" th:method="DELETE">
                                   <input type="hidden" name="_method" value="DELETE">
                                   <button class="link-delete-article" type="submit">삭제</button>
                               </form>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -36,10 +36,10 @@
                   <div class="article-util">
                       <ul class="article-util-list">
                           <li>
-                              <a class="link-modify-article" href="/questions/423/form">수정</a>
+                              <a class="link-modify-article" th:href="@{/questions/update/{articleId}(articleId = ${article.articleId})}">수정</a>
                           </li>
                           <li>
-                              <form class="form-delete" action="/questions/423" method="POST">
+                              <form class="form-delete" th:action="@{/questions/{articleId}(articleId=${article.articleId})}" th:method="DELETE">
                                   <input type="hidden" name="_method" value="DELETE">
                                   <button class="link-delete-article" type="submit">삭제</button>
                               </form>

--- a/src/main/resources/templates/qna/update_form.html
+++ b/src/main/resources/templates/qna/update_form.html
@@ -13,7 +13,7 @@
 <div class="container" id="main">
    <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
       <div class="panel panel-default content-main">
-          <form name="question" method="post" action="/question">
+          <form name="question" th:method="PUT" th:action="@{/question/{articleId}(articleId = ${articleId})}">
               <div class="form-group">
                   <label for="title">제목</label>
                   <input type="text" class="form-control" id="title" name="title" placeholder="제목"/>
@@ -22,7 +22,7 @@
                   <label for="contents">내용</label>
                   <textarea name="contents" id="contents" rows="5" class="form-control"></textarea>
               </div>
-              <button type="submit" class="btn btn-success clearfix pull-right">질문하기</button>
+              <button type="submit" class="btn btn-success clearfix pull-right">수정하기</button>
           </form>
         </div>
     </div>

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -21,7 +21,7 @@
               </thead>
               <tbody>
                   <tr th:each="user : ${users}">
-                      <th scope="row" th:text="${userStat.count}">번호</th> <td th:text="${user.userId}">회원id</td> <td><a th:href="@{/users/{userId}(userId=${user.userId})}" th:text="${user.name}">이름</a></td> <td th:text="${user.email}">이메일</td><td><a th:href="@{/users/{userId}/form(userId = ${user.userId})}" class="btn btn-success" role="button">수정</a></td>
+                      <th scope="row" th:text="${userStat.count}">번호</th> <td th:text="${user.userId}">회원id</td> <td><a th:href="@{/users/{userId}(userId=${user.userId})}" th:text="${user.name}">이름</a></td> <td th:text="${user.email}">이메일</td><td><a th:href="@{/users/update/{userId}(userId = ${user.userId})}" class="btn btn-success" role="button">수정</a></td>
                   </tr>
               </tbody>
           </table>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -12,7 +12,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="post" action="/users/login">
+          <form name="question" method="post" action="">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/test/java/codesquad/springcafe/controller/ArticleControllerTest.java
+++ b/src/test/java/codesquad/springcafe/controller/ArticleControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,7 +27,10 @@ class ArticleControllerTest {
     @Test
     @DisplayName("글 작성 폼으로 이동")
     void getQuestionFormTest() throws Exception {
-        mockMvc.perform(get("/question"))
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("loginUserId", "cori123");
+
+        mockMvc.perform(get("/question").session(session))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(view().name("qna/form"))
                 .andReturn();
@@ -35,12 +39,15 @@ class ArticleControllerTest {
     @Test
     @DisplayName("게시글을 저장 후 홈페이지로 리다이렉트")
     void writeQuestionTest() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("loginUserId", "cori123");
+
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/users")
                 .param("writer", "cori")
                 .param("title", "1234")
                 .param("contents", "hello world");
 
-        mockMvc.perform(post("/question"))
+        mockMvc.perform(post("/question").session(session))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
 

--- a/src/test/java/codesquad/springcafe/controller/ArticleControllerTest.java
+++ b/src/test/java/codesquad/springcafe/controller/ArticleControllerTest.java
@@ -1,6 +1,6 @@
 package codesquad.springcafe.controller;
 
-import codesquad.springcafe.repository.ArticleRepository;
+import codesquad.springcafe.service.ArticleService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(ArticleController.class)
@@ -22,7 +21,7 @@ class ArticleControllerTest {
     MockMvc mockMvc;
 
     @MockBean
-    ArticleRepository articleRepository;
+    ArticleService articleService;
 
     @Test
     @DisplayName("글 작성 폼으로 이동")
@@ -42,12 +41,12 @@ class ArticleControllerTest {
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("loginUserId", "cori123");
 
-        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/users")
-                .param("writer", "cori")
+        MockHttpServletRequestBuilder request = MockMvcRequestBuilders.post("/question")
                 .param("title", "1234")
-                .param("contents", "hello world");
+                .param("contents", "hello world")
+                .session(session);
 
-        mockMvc.perform(post("/question").session(session))
+        mockMvc.perform(request)
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
 

--- a/src/test/java/codesquad/springcafe/controller/UserControllerTest.java
+++ b/src/test/java/codesquad/springcafe/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -26,7 +27,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("회원가입을 하면 /users로 리다이렉트해야한다.")
-    public void testRegister() throws Exception {
+    void testRegister() throws Exception {
         // 테스트 데이터 준비
         String userId = "test_user";
         String password = "test_password";
@@ -59,12 +60,15 @@ class UserControllerTest {
     void updateUserTest() throws Exception {
         String userListUri = "/users";
         String updateUserUri = "/users/cori123";
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("loginUserId", "cori123");
 
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(updateUserUri)
                 .param("password", "1111")
                 .param("newPassword", "2222")
                 .param("name", "cori")
-                .param("email", "cori@naver.com");
+                .param("email", "cori@naver.com")
+                .session(session);
 
         mockMvc.perform(request)
                 .andExpect(status().is3xxRedirection())
@@ -78,12 +82,15 @@ class UserControllerTest {
 
         String userUpdateFormUri = "/users/cori123/form";
         String updateUserUri = "/users/cori123";
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("loginUserId", "cori123");
 
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.put(updateUserUri)
                 .param("password", "1111")
                 .param("newPassword", "2222")
                 .param("name", "cori")
-                .param("email", "cori@naver.com");
+                .param("email", "cori@naver.com")
+                .session(session);
 
         mockMvc.perform(request)
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/codesquad/springcafe/repository/ArticleMemoryRepositoryTest.java
+++ b/src/test/java/codesquad/springcafe/repository/ArticleMemoryRepositoryTest.java
@@ -24,7 +24,7 @@ class ArticleMemoryRepositoryTest {
         Article article = new Article(articleId, "cori", "안녕하세요", "오늘은 날씨가 흐립니다.");
         articleRepository.save(article);
 
-        Article findArticle = articleRepository.findById(articleId);
+        Article findArticle = articleRepository.findById(articleId).get();
 
         assertThat(findArticle).usingRecursiveComparison().isEqualTo(article);
     }

--- a/src/test/java/codesquad/springcafe/repository/ArticleMemoryRepositoryTest.java
+++ b/src/test/java/codesquad/springcafe/repository/ArticleMemoryRepositoryTest.java
@@ -20,12 +20,13 @@ class ArticleMemoryRepositoryTest {
     @Test
     @DisplayName("게시글을 저장할 수 있다.")
     void saveArticle() {
-        ArticleRequestDto articleRequestDto = new ArticleRequestDto("cori", "안녕하세요.", "오늘은 4월 11일 입니다.");
-        Long articleId = articleRepository.save(new Article(articleRequestDto));
+        Long articleId = 1L;
+        Article article = new Article(articleId, "cori", "안녕하세요", "오늘은 날씨가 흐립니다.");
+        articleRepository.save(article);
 
         Article findArticle = articleRepository.findById(articleId);
 
-        assertThat(findArticle).usingRecursiveComparison().isEqualTo(new Article(articleId, articleRequestDto));
+        assertThat(findArticle).usingRecursiveComparison().isEqualTo(article);
     }
 
 

--- a/src/test/java/codesquad/springcafe/repository/UserMemoryRepositoryTest.java
+++ b/src/test/java/codesquad/springcafe/repository/UserMemoryRepositoryTest.java
@@ -23,7 +23,7 @@ class UserMemoryRepositoryTest {
 
         userRepository.saveUser(user);
 
-        assertThat(userRepository.findUserById(user.getUserId())).isEqualTo(user);
+        assertThat(userRepository.findUserById(user.getUserId()).get()).isEqualTo(user);
     }
 
     @Test

--- a/src/test/java/codesquad/springcafe/service/UserServiceTest.java
+++ b/src/test/java/codesquad/springcafe/service/UserServiceTest.java
@@ -53,8 +53,8 @@ class UserServiceTest {
         User user = new User("cori", "1234", "old name", "cori@naver.com");
         userRepository.saveUser(user);
 
-        UserUpdateDto userUpdateDto = new UserUpdateDto("cori", "1234", "4321", "new name", "cori123@naver.com");
-        userService.update(userUpdateDto);
+        UserUpdateDto userUpdateDto = new UserUpdateDto("1234", "4321", "new name", "cori123@naver.com");
+        userService.update(userUpdateDto.toEntity("cori"));
 
         assertThat(user).usingRecursiveComparison().isEqualTo(new User("cori", "4321", "new name", "cori123@naver.com"));
     }
@@ -65,8 +65,8 @@ class UserServiceTest {
         User user = new User("cori", "1234", "old name", "cori@naver.com");
         userRepository.saveUser(user);
 
-        UserUpdateDto userUpdateDto = new UserUpdateDto("cori", "1111", "4321", "new name", "cori123@naver.com");
+        UserUpdateDto userUpdateDto = new UserUpdateDto("1111", "4321", "new name", "cori123@naver.com");
 
-        assertThatThrownBy(() -> userService.update(userUpdateDto)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> userService.update(userUpdateDto.toEntity("cori"))).isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## 구현 내용
### 구현 기능
- [x] 게시글 작성하기
	- [x] 로그인한 사용자만 글쓰기 가능
	- [x] 로그인한 사용자가 글쓴이가 되도록 변경
- [x] 게시글 수정하기
	- [x] `PUT` 메서드
	- [x] 로그인한 사용자의 글만 수정 가능
	- [x] "다른 사람의 글은 수정할 수 없습니다" 같은 에러 메시지 출력하는 페이지로 이동
- [x] 게시글 삭제하기
	- [x] `DELETE` 메서드
	- [x] 로그인한 사용자의 글만 삭제 가능
	- [x] "다른 사람의 글은 삭제할 수 없습니다" 같은 에러 메시지 출력하는 페이지로 이동
- [x] 로그인 창으로 리다이렉트할 때 원래 uri로 리다이렉트 하도록 변경
- [x] Article이 User의 pk를 외래키로 가지도록 변경

### URI
| URI                                 | 기능          |
| ----------------------------------- | ----------- |
| `GET /users`                        | 사용자 목록      |
| `POST /users`                       | 회원 가입 기능    |
| `GET /users/{userId}`               | 회원 프로필 조회   |
| `GET /questions`                    | 글쓰기 페이지     |
| `POST /questions`                   | 글쓰기 기능      |
| `GET /questions/{articleId}`        | 게시글 상세 보기   |
| `GET /questions/update/{articleId}` | 게시글 수정 페이지  |
| `PUT /questions/{articleId}`        | 게시글 수정      |
| `DELETE /questions/{articleId}`     | 게시글 삭제      |
| `GET /users/{userId}/form`          | 회원정보 수정 페이지 |
| `PUT /users/{userId}`               | 회원정보 수정     |
| `POST /users/login`                 | 로그인 기능      |
| `POST /users/logout`                | 로그아웃 기능     |

## 테이블
- USERS 테이블
	- 사용자 아이디를 PK로 설정
```sql
create table users  
(  
    user_id  varchar(30) NOT NULL,  
    password varchar(30) NOT NULL,  
    name     varchar(20) NOT NULL,  
    email    varchar(30) NOT NULL,  
    PRIMARY KEY (user_id)  
);
```

- ARTICLES 테이블
	- 자동으로 증가하는 시퀀스를 PK로 설정
	- USERS 테이블의 user_id를 FK로 설정
```sql
CREATE TABLE articles (  
    article_id BIGINT PRIMARY KEY AUTO_INCREMENT,  
    writer VARCHAR(30) NOT NULL,  
    title VARCHAR(255) NOT NULL,  
    contents TEXT NOT NULL,  
    local_date_time TIMESTAMP NOT NULL,  
    hits INT NOT NULL,  
    FOREIGN KEY (writer) REFERENCES users(user_id)  
);
```


## 고민 사항
게시글을 업데이트할 때 두 가지 방법을 고민했습니다.  
1. `article.update(UpdateArticle)`와 같은 메서드로 `Article` 객체의 값을 변화시킨 뒤 `repository`로 넘겨주기
2. `ArticleRepository.update(articleId, UpdateArticle)`같이 필요한 정보만 `repository`에 넘겨 업데이트 쿼리를 실행시키기

`User` 객체를 업데이트할 때에는 첫번째 방법을 선택했었는데, 이때는 User 객체의 모든 필드가 업테이트 쿼리를 날릴 때 필요한 정보라고 생각했기 때문입니다.
  `Article` 클래스를 처음 만들 때 제목과 내용을 final로 선언했기 때문에 첫번째 방법으로 게시글 정보를 수정하려면 final 키워드를 제거해야했기 때문에 두번째 방법을 선택했습니다.
객체의 불변성을 유지하는게 더 좋을 거라고 생각했기 때문인데, 첫번째 방법이 더 객체지향적이지 않나 하는 생각이 들었습니다.  
