### PR TITLE
[코리] Step-6 댓글 구현

### DIFF
--- a/src/main/java/codesquad/springcafe/config/AppConfig.java
+++ b/src/main/java/codesquad/springcafe/config/AppConfig.java
@@ -1,6 +1,6 @@
 package codesquad.springcafe.config;
 
-import codesquad.springcafe.interceptor.AuthenticationInterceptor;
+import codesquad.springcafe.interceptor.LoginInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -11,7 +11,7 @@ public class AppConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
 
-        registry.addInterceptor(new AuthenticationInterceptor())
+        registry.addInterceptor(new LoginInterceptor())
                 .addPathPatterns("/**")
                 .excludePathPatterns("/css/**", "/fonts/**", "/js/**", "/images/**", "/", "/users/login", "/users", "/users/join");
 

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -3,7 +3,9 @@ package codesquad.springcafe.controller;
 import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.model.Article;
+import codesquad.springcafe.model.Reply;
 import codesquad.springcafe.service.ArticleService;
+import codesquad.springcafe.service.ReplyService;
 import jakarta.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,19 +13,23 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+import static codesquad.springcafe.controller.UserController.LOGIN_USER_ID;
+
 @Controller
 @RequestMapping("/question")
 public class ArticleController {
 
-    public static final String LOGIN_USER_ID = "loginUserId";
     public static final String ARTICLE_ID = "articleId";
 
     private final Logger log = LoggerFactory.getLogger(ArticleController.class);
     private final ArticleService articleService;
+    private final ReplyService replyService;
 
-
-    public ArticleController(ArticleService articleService) {
+    public ArticleController(ArticleService articleService, ReplyService replyService) {
         this.articleService = articleService;
+        this.replyService = replyService;
     }
 
     @GetMapping
@@ -41,9 +47,11 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     public String getArticle(@PathVariable Long articleId, Model model) {
+        log.debug("getArticle : {}", articleId);
         Article article = articleService.findById(articleId);
-        log.debug("getArticle : {}", article);
+        List<Reply> replies = replyService.findRepliesByArticle(articleId);
         model.addAttribute("article", article);
+        model.addAttribute("replies", replies);
         return "qna/show";
     }
 

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -58,17 +58,16 @@ public class ArticleController {
     @GetMapping("/update/{articleId}")
     public String getArticleUpdateForm(@PathVariable Long articleId, HttpSession session, Model model) {
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
-        if (articleService.checkArticleWriter(articleId, userId)) {
-            log.debug("게시물 수정 성공 {}", userId);
-            model.addAttribute(ARTICLE_ID, articleId);
-            return "qna/update_form";
-        }
-        log.debug("게시물 수정 실패 {}", userId);
-        throw new UnauthorizedAccessException("본인의 게시글만 수정할 수 있습니다.");
+        articleService.validateArticleWriter(articleId, userId);
+
+        model.addAttribute(ARTICLE_ID, articleId);
+        return "qna/update_form";
     }
 
     @PutMapping("/{articleId}")
-    public String updateArticle(@PathVariable Long articleId, @ModelAttribute ArticleRequestDto articleRequestDto) {
+    public String updateArticle(@PathVariable Long articleId, @ModelAttribute ArticleRequestDto articleRequestDto, HttpSession session) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        articleService.validateArticleWriter(articleId, userId);
         articleService.update(articleId, articleRequestDto);
         return "redirect:/question/" + articleId;
     }
@@ -76,12 +75,10 @@ public class ArticleController {
     @DeleteMapping("/{articleId}")
     public String deleteArticle(@PathVariable Long articleId, HttpSession session){
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
-        if (articleService.checkArticleWriter(articleId, userId)) {
-            log.debug("게시물 삭제 성공 {}", userId);
-            articleService.delete(articleId);
-            return "redirect:/";
-        }
-        log.debug("게시물 삭제 실패 {}", userId);
-        throw new UnauthorizedAccessException("본인의 게시글만 삭제할 수 있습니다.");
+        articleService.validateArticleWriter(articleId, userId);
+
+        log.debug("게시물 삭제 성공 {}", userId);
+        articleService.delete(articleId);
+        return "redirect:/";
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/controller/ArticleController.java
@@ -67,13 +67,13 @@ public class ArticleController {
         throw new UnauthorizedAccessException("본인의 게시글만 수정할 수 있습니다.");
     }
 
-    @PutMapping("{articleId}")
+    @PutMapping("/{articleId}")
     public String updateArticle(@PathVariable Long articleId, @ModelAttribute ArticleRequestDto articleRequestDto) {
         articleService.update(articleId, articleRequestDto);
         return "redirect:/question/" + articleId;
     }
 
-    @DeleteMapping("{articleId}")
+    @DeleteMapping("/{articleId}")
     public String deleteArticle(@PathVariable Long articleId, HttpSession session){
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
         if (articleService.checkArticleWriter(articleId, userId)) {

--- a/src/main/java/codesquad/springcafe/controller/ErrorController.java
+++ b/src/main/java/codesquad/springcafe/controller/ErrorController.java
@@ -1,9 +1,6 @@
 package codesquad.springcafe.controller;
 
-import codesquad.springcafe.exception.ArticleNotFountException;
-import codesquad.springcafe.exception.ReplyNotFound;
-import codesquad.springcafe.exception.UnauthorizedAccessException;
-import codesquad.springcafe.exception.UserNotFoundException;
+import codesquad.springcafe.exception.*;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.ModelAndView;
@@ -11,7 +8,7 @@ import org.springframework.web.servlet.ModelAndView;
 @ControllerAdvice
 public class ErrorController {
 
-    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class, UnauthorizedAccessException.class, ReplyNotFound.class})
+    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class, UnauthorizedAccessException.class, ReplyNotFound.class, CannotDeleteArticleWithRepliesException.class})
     public ModelAndView handleException(Exception e) {
         ModelAndView model = new ModelAndView("errors/error");
         model.addObject("errorMessage", e.getMessage());

--- a/src/main/java/codesquad/springcafe/controller/ErrorController.java
+++ b/src/main/java/codesquad/springcafe/controller/ErrorController.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.controller;
 
 import codesquad.springcafe.exception.ArticleNotFountException;
+import codesquad.springcafe.exception.ReplyNotFound;
 import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.exception.UserNotFoundException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,7 +11,7 @@ import org.springframework.web.servlet.ModelAndView;
 @ControllerAdvice
 public class ErrorController {
 
-    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class, UnauthorizedAccessException.class})
+    @ExceptionHandler(value = {UserNotFoundException.class, ArticleNotFountException.class, UnauthorizedAccessException.class, ReplyNotFound.class})
     public ModelAndView handleException(Exception e) {
         ModelAndView model = new ModelAndView("errors/error");
         model.addObject("errorMessage", e.getMessage());

--- a/src/main/java/codesquad/springcafe/controller/ReplyController.java
+++ b/src/main/java/codesquad/springcafe/controller/ReplyController.java
@@ -1,12 +1,10 @@
 package codesquad.springcafe.controller;
 
+import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.service.ReplyService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import static codesquad.springcafe.controller.UserController.LOGIN_USER_ID;
 
@@ -27,4 +25,13 @@ public class ReplyController {
         return "redirect:/question/" + questionId;
     }
 
+    @DeleteMapping("/{replyId}")
+    public String deleteReply(@PathVariable Long questionId, @PathVariable Long replyId, HttpSession session) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        if (replyService.checkReplyAuthor(replyId, userId)) {
+            replyService.delete(replyId);
+            return "redirect:/question/" + questionId;
+        }
+        throw new UnauthorizedAccessException("본인의 댓글만 삭제할 수 있습니다.");
+    }
 }

--- a/src/main/java/codesquad/springcafe/controller/ReplyController.java
+++ b/src/main/java/codesquad/springcafe/controller/ReplyController.java
@@ -28,10 +28,8 @@ public class ReplyController {
     @DeleteMapping("/{replyId}")
     public String deleteReply(@PathVariable Long questionId, @PathVariable Long replyId, HttpSession session) {
         String userId = (String) session.getAttribute(LOGIN_USER_ID);
-        if (replyService.checkReplyAuthor(replyId, userId)) {
-            replyService.delete(replyId);
-            return "redirect:/question/" + questionId;
-        }
-        throw new UnauthorizedAccessException("본인의 댓글만 삭제할 수 있습니다.");
+        replyService.validateReplyAuthor(replyId, userId);
+        replyService.delete(replyId);
+        return "redirect:/question/" + questionId;
     }
 }

--- a/src/main/java/codesquad/springcafe/controller/ReplyController.java
+++ b/src/main/java/codesquad/springcafe/controller/ReplyController.java
@@ -1,0 +1,30 @@
+package codesquad.springcafe.controller;
+
+import codesquad.springcafe.service.ReplyService;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static codesquad.springcafe.controller.UserController.LOGIN_USER_ID;
+
+@Controller
+@RequestMapping("/question/{questionId}/answers")
+public class ReplyController {
+
+    private final ReplyService replyService;
+
+    public ReplyController(ReplyService replyService) {
+        this.replyService = replyService;
+    }
+
+    @PostMapping
+    public String createReply(@PathVariable Long questionId, @RequestParam String content, HttpSession session) {
+        String userId = (String) session.getAttribute(LOGIN_USER_ID);
+        replyService.createReply(userId, questionId, content);
+        return "redirect:/question/" + questionId;
+    }
+
+}

--- a/src/main/java/codesquad/springcafe/exception/CannotDeleteArticleWithRepliesException.java
+++ b/src/main/java/codesquad/springcafe/exception/CannotDeleteArticleWithRepliesException.java
@@ -1,0 +1,8 @@
+package codesquad.springcafe.exception;
+
+public class CannotDeleteArticleWithRepliesException extends RuntimeException {
+
+    public CannotDeleteArticleWithRepliesException() {
+        super("댓글이 있는 게시글은 삭제할 수 없습니다.");
+    }
+}

--- a/src/main/java/codesquad/springcafe/exception/ReplyNotFound.java
+++ b/src/main/java/codesquad/springcafe/exception/ReplyNotFound.java
@@ -1,0 +1,8 @@
+package codesquad.springcafe.exception;
+
+public class ReplyNotFound extends RuntimeException {
+
+    public ReplyNotFound() {
+        super("존재하지 않는 댓글입니다.");
+    }
+}

--- a/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/codesquad/springcafe/interceptor/AuthenticationInterceptor.java
@@ -5,9 +5,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-public class AuthenticationInterceptor implements HandlerInterceptor {
+import static codesquad.springcafe.controller.UserController.LOGIN_USER_ID;
 
-    public static final String LOGIN_USER_ID = "loginUserId";
+public class AuthenticationInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {

--- a/src/main/java/codesquad/springcafe/interceptor/LoginInterceptor.java
+++ b/src/main/java/codesquad/springcafe/interceptor/LoginInterceptor.java
@@ -7,7 +7,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import static codesquad.springcafe.controller.UserController.LOGIN_USER_ID;
 
-public class AuthenticationInterceptor implements HandlerInterceptor {
+public class LoginInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {

--- a/src/main/java/codesquad/springcafe/model/Article.java
+++ b/src/main/java/codesquad/springcafe/model/Article.java
@@ -4,6 +4,8 @@ import codesquad.springcafe.dto.ArticleRequestDto;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class Article {
@@ -14,6 +16,17 @@ public class Article {
     private final String contents;
     private final LocalDateTime localDateTime;
     private AtomicLong hits;
+    private boolean deleted;
+
+    public Article(Long articleId, String writer, String title, String contents, LocalDateTime localDateTime, Long hits, boolean deleted) {
+        this.articleId = articleId;
+        this.writer = writer;
+        this.title = title;
+        this.contents = contents;
+        this.localDateTime = localDateTime;
+        this.hits = new AtomicLong(hits);
+        this.deleted = deleted;
+    }
 
     public Article(Long articleId, String writer, String title, String contents, LocalDateTime localDateTime, long hits) {
         this.articleId = articleId;
@@ -22,6 +35,7 @@ public class Article {
         this.contents = contents;
         this.localDateTime = localDateTime;
         this.hits = new AtomicLong(hits);
+        this.deleted = false;
     }
 
     public Article(Long articleId, String writer, String title, String contents) {
@@ -31,6 +45,7 @@ public class Article {
         this.contents = contents;
         this.localDateTime = LocalDateTime.now();
         this.hits = new AtomicLong();
+        this.deleted = false;
     }
 
     public Article(long articleId, String writer, ArticleRequestDto articleRequestDto) {
@@ -43,6 +58,7 @@ public class Article {
         this.contents = articleRequestDto.getContents();
         this.localDateTime = LocalDateTime.now();
         this.hits = new AtomicLong();
+        this.deleted = false;
     }
 
     public Long getArticleId() {
@@ -67,6 +83,10 @@ public class Article {
 
     public long getHits() {
         return hits.get();
+    }
+
+    public boolean isDeleted() {
+        return deleted;
     }
 
     public void setArticleId(Long articleId) {

--- a/src/main/java/codesquad/springcafe/model/Article.java
+++ b/src/main/java/codesquad/springcafe/model/Article.java
@@ -61,7 +61,7 @@ public class Article {
         return contents;
     }
 
-    public String getLocalDateTime() {
+    public String getCreatedTime() {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 

--- a/src/main/java/codesquad/springcafe/model/Reply.java
+++ b/src/main/java/codesquad/springcafe/model/Reply.java
@@ -1,0 +1,63 @@
+package codesquad.springcafe.model;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class Reply {
+
+    private Long replyId;
+    private Long articleId;
+    private String author;
+    private String content;
+    private LocalDateTime createdAt;
+    private boolean deleted;
+
+    public Reply(Long articleId, String author, String content) {
+        this.articleId = articleId;
+        this.author = author;
+        this.content = content;
+        this.createdAt = LocalDateTime.now();
+        this.deleted = false;
+    }
+
+    public Reply(Long replyId, Long articleId, String author, String content, LocalDateTime createdAt, boolean deleted) {
+        this.replyId = replyId;
+        this.articleId = articleId;
+        this.author = author;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.deleted = deleted;
+    }
+
+    public Long getReplyId() {
+        return replyId;
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public String getDateTime() {
+        return createdAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public void setReplyId(Long replyId) {
+        this.replyId = replyId;
+    }
+}

--- a/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ArticleJdbcRepository.java
@@ -35,7 +35,7 @@ public class ArticleJdbcRepository implements ArticleRepository {
         parameters.put("writer", article.getWriter());
         parameters.put("title", article.getTitle());
         parameters.put("contents", article.getContents());
-        parameters.put("local_date_time", article.getLocalDateTime());
+        parameters.put("local_date_time", article.getCreatedTime());
         parameters.put("hits", article.getHits());
 
         Number key = jdbcInsert.executeAndReturnKey(parameters);

--- a/src/main/java/codesquad/springcafe/repository/ReplyJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ReplyJdbcRepository.java
@@ -33,7 +33,7 @@ public class ReplyJdbcRepository implements ReplyRepository {
         parameters.put("article_id", reply.getArticleId());
         parameters.put("author", reply.getAuthor());
         parameters.put("content", reply.getContent());
-        parameters.put("createdAt", reply.getCreatedAt());
+        parameters.put("created_at", reply.getCreatedAt());
         parameters.put("deleted", reply.isDeleted());
 
         Number key = jdbcInsert.executeAndReturnKey(parameters);
@@ -44,7 +44,7 @@ public class ReplyJdbcRepository implements ReplyRepository {
 
     @Override
     public Optional<Reply> findById(Long replyId) {
-        String sql = "SELECT reply_id, article_id, author, content, createdAt, deleted FROM reply WHERE reply_id = ?";
+        String sql = "SELECT reply_id, article_id, author, content, created_at, deleted FROM reply WHERE reply_id = ?";
         try {
             Reply reply = jdbcTemplate.queryForObject(sql, replyRowMapper(), replyId);
             return Optional.ofNullable(reply);
@@ -55,7 +55,7 @@ public class ReplyJdbcRepository implements ReplyRepository {
 
     @Override
     public List<Reply> findRepliesByArticleId(Long articleId) {
-        String sql = "SELECT reply_id, article_id, author, content, createdAt, deleted FROM reply";
+        String sql = "SELECT reply_id, article_id, author, content, created_at, deleted FROM reply";
         List<Reply> replies = jdbcTemplate.query(sql, replyRowMapper());
 
         return replies.stream()
@@ -80,7 +80,7 @@ public class ReplyJdbcRepository implements ReplyRepository {
             long articleId = rs.getLong("article_id");
             String author = rs.getString("author");
             String content = rs.getString("content");
-            LocalDateTime createdAt = rs.getTimestamp("createdAt").toLocalDateTime();
+            LocalDateTime createdAt = rs.getTimestamp("created_at").toLocalDateTime();
             boolean deleted = rs.getBoolean("deleted");
 
             return new Reply(replyId, articleId, author, content, createdAt, deleted);

--- a/src/main/java/codesquad/springcafe/repository/ReplyJdbcRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ReplyJdbcRepository.java
@@ -1,0 +1,84 @@
+package codesquad.springcafe.repository;
+
+import codesquad.springcafe.exception.ArticleNotFountException;
+import codesquad.springcafe.model.Article;
+import codesquad.springcafe.model.Reply;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+public class ReplyJdbcRepository implements ReplyRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ReplyJdbcRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Reply save(Reply reply) {
+        SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(jdbcTemplate);
+        jdbcInsert.withTableName("reply").usingGeneratedKeyColumns("reply_id");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("article_id", reply.getArticleId());
+        parameters.put("author", reply.getAuthor());
+        parameters.put("content", reply.getContent());
+        parameters.put("createdAt", reply.getCreatedAt());
+        parameters.put("deleted", reply.isDeleted());
+
+        Number key = jdbcInsert.executeAndReturnKey(parameters);
+        reply.setReplyId((key.longValue()));
+
+        return reply;
+    }
+
+    @Override
+    public Optional<Reply> findById(Long replyId) {
+        String sql = "SELECT reply_id, article_id, author, content, createdAt, deleted FROM reply WHERE reply_id = ?";
+        try {
+            Reply reply = jdbcTemplate.queryForObject(sql, replyRowMapper(), replyId);
+            return Optional.ofNullable(reply);
+        } catch (EmptyResultDataAccessException e) {
+            throw new ArticleNotFountException();
+        }
+    }
+
+    @Override
+    public List<Reply> findRepliesByArticleId(Long articleId) {
+        String sql = "SELECT reply_id, article_id, author, content, createdAt, deleted FROM reply";
+        List<Reply> replies = jdbcTemplate.query(sql, replyRowMapper());
+
+        return replies.stream()
+                .filter(reply -> reply.getArticleId().equals(articleId))
+                .toList();
+    }
+
+    @Override
+    public void delete(Long replyId) {
+        String sql = "DELETE FROM reply WHERE reply_id = ?";
+        jdbcTemplate.update(sql, replyId);
+    }
+
+    private RowMapper<Reply> replyRowMapper() {
+        return (rs, rowNum) -> {
+            long replyId = rs.getLong("reply_id");
+            long articleId = rs.getLong("article_id");
+            String author = rs.getString("author");
+            String content = rs.getString("content");
+            LocalDateTime createdAt = rs.getTimestamp("createdAt").toLocalDateTime();
+            boolean deleted = rs.getBoolean("deleted");
+
+            return new Reply(replyId, articleId, author, content, createdAt, deleted);
+        };
+    }
+}

--- a/src/main/java/codesquad/springcafe/repository/ReplyRepository.java
+++ b/src/main/java/codesquad/springcafe/repository/ReplyRepository.java
@@ -1,0 +1,18 @@
+package codesquad.springcafe.repository;
+
+import codesquad.springcafe.model.Reply;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReplyRepository {
+
+    Reply save(Reply reply);
+
+    Optional<Reply> findById(Long replyId);
+
+    List<Reply> findRepliesByArticleId(Long articleId);
+
+    void delete(Long replyId);
+
+}

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -2,21 +2,26 @@ package codesquad.springcafe.service;
 
 import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.exception.ArticleNotFountException;
+import codesquad.springcafe.exception.CannotDeleteArticleWithRepliesException;
 import codesquad.springcafe.model.Article;
+import codesquad.springcafe.model.Reply;
 import codesquad.springcafe.repository.ArticleRepository;
+import codesquad.springcafe.repository.ReplyRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final ReplyRepository replyRepository;
 
-    public ArticleService(ArticleRepository articleRepository) {
+    public ArticleService(ArticleRepository articleRepository, ReplyRepository replyRepository) {
         this.articleRepository = articleRepository;
+        this.replyRepository = replyRepository;
     }
-
 
     public void createArticle(Article article) {
         articleRepository.save(article);
@@ -40,6 +45,10 @@ public class ArticleService {
     }
 
     public void delete(Long articleId) {
+        List<Reply> replies = replyRepository.findRepliesByArticleId(articleId);
+        if (!replies.isEmpty()) {
+            throw new CannotDeleteArticleWithRepliesException();
+        }
         articleRepository.delete(articleId);
     }
 }

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -3,6 +3,7 @@ package codesquad.springcafe.service;
 import codesquad.springcafe.dto.ArticleRequestDto;
 import codesquad.springcafe.exception.ArticleNotFountException;
 import codesquad.springcafe.exception.CannotDeleteArticleWithRepliesException;
+import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.model.Article;
 import codesquad.springcafe.model.Reply;
 import codesquad.springcafe.repository.ArticleRepository;
@@ -50,5 +51,12 @@ public class ArticleService {
             throw new CannotDeleteArticleWithRepliesException();
         }
         articleRepository.delete(articleId);
+    }
+
+    public void validateArticleWriter(Long articleId, String userId) {
+        Article article = findById(articleId);
+        if (!article.checkWriter(userId)) {
+            throw new UnauthorizedAccessException("다른 사람의 게시글에 접근할 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/codesquad/springcafe/service/ReplyService.java
+++ b/src/main/java/codesquad/springcafe/service/ReplyService.java
@@ -1,6 +1,7 @@
 package codesquad.springcafe.service;
 
 import codesquad.springcafe.exception.ReplyNotFound;
+import codesquad.springcafe.exception.UnauthorizedAccessException;
 import codesquad.springcafe.model.Reply;
 import codesquad.springcafe.repository.ReplyRepository;
 import org.springframework.stereotype.Service;
@@ -38,8 +39,10 @@ public class ReplyService {
         throw new ReplyNotFound();
     }
 
-    public boolean checkReplyAuthor(Long replyId, String userId) {
+    public void validateReplyAuthor(Long replyId, String userId) {
         Reply reply = findById(replyId);
-        return reply.getAuthor().equals(userId);
+        if (!userId.equals(reply.getAuthor())) {
+            throw new UnauthorizedAccessException("본인의 댓글만 수정/삭제가 가능합니다.");
+        }
     }
 }

--- a/src/main/java/codesquad/springcafe/service/ReplyService.java
+++ b/src/main/java/codesquad/springcafe/service/ReplyService.java
@@ -1,0 +1,26 @@
+package codesquad.springcafe.service;
+
+import codesquad.springcafe.model.Reply;
+import codesquad.springcafe.repository.ReplyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ReplyService {
+
+    private final ReplyRepository replyRepository;
+
+    public ReplyService(ReplyRepository replyRepository) {
+        this.replyRepository = replyRepository;
+    }
+
+    public void createReply(String userId, Long articleId, String content) {
+        Reply reply = new Reply(articleId, userId, content);
+        replyRepository.save(reply);
+    }
+
+    public List<Reply> findRepliesByArticle(Long articleId) {
+        return replyRepository.findRepliesByArticleId(articleId);
+    }
+}

--- a/src/main/java/codesquad/springcafe/service/ReplyService.java
+++ b/src/main/java/codesquad/springcafe/service/ReplyService.java
@@ -1,10 +1,12 @@
 package codesquad.springcafe.service;
 
+import codesquad.springcafe.exception.ReplyNotFound;
 import codesquad.springcafe.model.Reply;
 import codesquad.springcafe.repository.ReplyRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ReplyService {
@@ -22,5 +24,22 @@ public class ReplyService {
 
     public List<Reply> findRepliesByArticle(Long articleId) {
         return replyRepository.findRepliesByArticleId(articleId);
+    }
+
+    public void delete(Long replyId) {
+        replyRepository.delete(replyId);
+    }
+
+    public Reply findById(Long replyId) {
+        Optional<Reply> optionalReply = replyRepository.findById(replyId);
+        if (optionalReply.isPresent()) {
+            return optionalReply.get();
+        }
+        throw new ReplyNotFound();
+    }
+
+    public boolean checkReplyAuthor(Long replyId, String userId) {
+        Reply reply = findById(replyId);
+        return reply.getAuthor().equals(userId);
     }
 }

--- a/src/main/java/codesquad/springcafe/service/UserService.java
+++ b/src/main/java/codesquad/springcafe/service/UserService.java
@@ -41,7 +41,7 @@ public class UserService {
         userRepository.update(user);
     }
 
-    public boolean isValidUser(String userId, String password) {
+    public boolean isPasswordMatch(String userId, String password) {
         User user = findUserById(userId);
         return user.validatePassword(password);
     }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -23,7 +23,7 @@
                           </strong>
                           <div class="auth-info">
                               <i class="icon-add-comment"></i>
-                              <span class="time" th:text="${article.localDateTime}">local date time</span>
+                              <span class="time" th:text="${article.getCreatedTime()}">local date time</span>
                               <a th:href="@{/users/{userId}(userId = ${article.writer})}" class="author" th:text="${article.writer}"> 글쓴이 </a>
                           </div>
                           <div class="reply" title="댓글">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -52,77 +52,51 @@
               </article>
 
               <div class="qna-comment">
-                  <div class="qna-comment-slipp">
-                      <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                  <div class="qna-comment-slipp" th:each="reply : ${replies}">
+                      <p class="qna-comment-count"><strong th:text="${replyStat.count}">number of comments</strong>개의 의견</p>
                       <div class="qna-comment-slipp-articles">
-
-                          <article class="article" id="answer-1405">
+                          <article class="article">
                               <div class="article-header">
                                   <div class="article-header-thumb">
                                       <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
                                   </div>
                                   <div class="article-header-text">
-                                      <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                      <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                          2016-01-12 14:06
+                                      <a th:href="@{/users/${reply.author}}" class="article-author-name" th:text="${reply.author}">
+                                          author
+                                      </a>
+                                      <a class="article-header-time" title="퍼머링크" th:text="${reply.getDateTime()}">
+                                          Date Time
                                       </a>
                                   </div>
                               </div>
                               <div class="article-doc comment-doc">
-                                  <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+                                  <p th:text="${reply.content}"> content </p>
                               </div>
                               <div class="article-util">
                                   <ul class="article-util-list">
                                       <li>
-                                          <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
+                                          <a class="link-modify-article" th:href="@{/questions/{questionId}/answers/{replyId}/form(questionId = ${articleId}, replyId = ${reply.replyId})}">
+                                              수정
+                                          </a>
                                       </li>
                                       <li>
-                                          <form class="delete-answer-form" action="/questions/413/answers/1405" method="POST">
-                                              <input type="hidden" name="_method" value="DELETE">
+                                          <form class="delete-answer-form" th:action="@{/questions/{questionId}/answers/{replyId}(questionId = ${articleId}, replyId = ${reply.replyId})}" th:method="DELETE">
                                               <button type="submit" class="delete-answer-button">삭제</button>
                                           </form>
                                       </li>
                                   </ul>
                               </div>
                           </article>
-                          <article class="article" id="answer-1406">
-                              <div class="article-header">
-                                  <div class="article-header-thumb">
-                                      <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-                                  </div>
-                                  <div class="article-header-text">
-                                      <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                      <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                          2016-01-12 14:06
-                                      </a>
-                                  </div>
-                              </div>
-                              <div class="article-doc comment-doc">
-                                  <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                              </div>
-                              <div class="article-util">
-                                  <ul class="article-util-list">
-                                      <li>
-                                          <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>
-                                      </li>
-                                      <li>
-                                          <form class="form-delete" action="/questions/413/answers/1405" method="POST">
-                                              <input type="hidden" name="_method" value="DELETE">
-                                              <button type="submit" class="delete-answer-button">삭제</button>
-                                          </form>
-                                      </li>
-                                  </ul>
-                              </div>
-                          </article>
-                          <form class="submit-write">
-                              <div class="form-group" style="padding:14px;">
-                                  <textarea class="form-control" placeholder="Update your status"></textarea>
-                              </div>
-                              <button class="btn btn-success pull-right" type="button">답변하기</button>
-<!--                              <div class="clearfix" />-->
-                          </form>
                       </div>
                   </div>
+
+                  <form class="submit-write" th:action="@{/question/{questionId}/answers(questionId=${article.articleId})}" th:method="POST">
+                      <div class="form-group" style="padding:14px;">
+                          <textarea class="form-control" name="content" placeholder="Update your status"></textarea>
+                      </div>
+                      <button class="btn btn-success pull-right" type="submit">답변하기</button>
+                  </form>
+
               </div>
           </div>
         </div>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -24,7 +24,7 @@
                       </div>
                       <div class="article-header-text">
                           <a th:href="@{/users/{userId}(userId = ${article.writer})}" class="article-author-name" th:text="${article.writer}"> writer </a>
-                          <span class="article-header-time" title="퍼머링크" th:text="${article.localDateTime}">
+                          <span class="article-header-time" title="퍼머링크" th:text="${article.createdTime}">
                               local date time
                               <i class="icon-link"></i>
                           </span>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -52,8 +52,8 @@
               </article>
 
               <div class="qna-comment">
-                  <div class="qna-comment-slipp" th:each="reply : ${replies}">
-                      <p class="qna-comment-count"><strong th:text="${replyStat.count}">number of comments</strong>개의 의견</p>
+                  <p class="qna-comment-count"><strong th:text="${replies.size()}">number of comments</strong>개의 의견</p>
+                    <div class="qna-comment-slipp" th:each="reply : ${replies}">
                       <div class="qna-comment-slipp-articles">
                           <article class="article">
                               <div class="article-header">
@@ -75,12 +75,12 @@
                               <div class="article-util">
                                   <ul class="article-util-list">
                                       <li>
-                                          <a class="link-modify-article" th:href="@{/questions/{questionId}/answers/{replyId}/form(questionId = ${articleId}, replyId = ${reply.replyId})}">
+                                          <a class="link-modify-article" th:href="@{/question/{questionId}/answers/{replyId}/form(questionId = ${articleId}, replyId = ${reply.replyId})}">
                                               수정
                                           </a>
                                       </li>
                                       <li>
-                                          <form class="delete-answer-form" th:action="@{/questions/{questionId}/answers/{replyId}(questionId = ${articleId}, replyId = ${reply.replyId})}" th:method="DELETE">
+                                          <form class="delete-answer-form" th:action="@{/question/{questionId}/answers/{replyId}(questionId = ${articleId}, replyId = ${reply.replyId})}" th:method="DELETE">
                                               <button type="submit" class="delete-answer-button">삭제</button>
                                           </form>
                                       </li>
@@ -124,8 +124,7 @@
 			</li>
 			<li>
 				<form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-					<input type="hidden" name="_method" value="DELETE">
-                     <button type="submit" class="delete-answer-button">삭제</button>
+                    <button type="submit" class="delete-answer-button">삭제</button>
 				</form>
 			</li>
 		</ul>


### PR DESCRIPTION
## 구현 내용
- [x] 댓글 기능 구현
	- [x] 댓글 작성
	- [x] 댓글 삭제
	- [x] 댓글 테이블 생성
- [x] 게시물 삭제
	- [x] Article의 deleted 필드를 변경
	- [x] 댓글이 없는 경우만 삭제 가능
	- [x] 본인 게시물만 삭제 가능

- [x] UserController의 updateUser 로직 변경
	- [x] {회원정보, 게시물, 댓글} 등 본인이 할 수 있는 로직 중복 제거 (`UnauthorizedAccessException`)


### URI
| URI                                                | 기능          |
| -------------------------------------------------- | ----------- |
| `GET /users`                                       | 사용자 목록      |
| `POST /users`                                      | 회원 가입 기능    |
| `GET /users/{userId}`                              | 회원 프로필 조회   |
| `GET /questions`                                   | 글쓰기 페이지     |
| `POST /questions`                                  | 글쓰기 기능      |
| `GET /questions/{articleId}`                       | 게시글 상세 보기   |
| `GET /questions/update/{articleId}`                | 게시글 수정 페이지  |
| `PUT /questions/{articleId}`                       | 게시글 수정      |
| `DELETE /questions/{articleId}`                    | 게시글 삭제      |
| `GET /users/{userId}/form`                         | 회원정보 수정 페이지 |
| `PUT /users/{userId}`                              | 회원정보 수정     |
| `POST /users/login`                                | 로그인 기능      |
| `POST /users/logout`                               | 로그아웃 기능     |
| `POST /question/{questionId}/answers`              | 댓글 작성 기능    |
| `DELETE /question/{questionId}/answers/{replyId}` | 댓글 삭제 기능    |


### 테이블
```sql
CREATE TABLE reply (
    reply_id    BIGINT PRIMARY KEY AUTO_INCREMENT,
    article_id  BIGINT NOT NULL,
    author      VARCHAR(30) NOT NULL,
    content     TEXT NOT NULL,
    createdAt   TIMESTAMP NOT NULL,
    deleted     boolean NOT NULL,
    FOREIGN KEY (article_id) REFERENCES articles(article_id),
    FOREIGN KEY (author) REFERENCES users(user_id)
```

## 고민 사항
게시물 삭제 기능을 구현할 때 댓글이 존재하면 삭제가 불가능하도록 구현해야 했습니다.
댓글 테이블은 게시글을 외래 키로 가지고 있는데, 해당 게시글에 댓글이 존재하는지 확인하기 위해 `SELECT * FROM REPLY WHERE article_id = {특정 게시글 아이디}` 쿼리를 날려야 했습니다.
게시글 하나를 삭제할 때 댓글 테이블을 full scan 하는게 비효율적이라는 생각이 들었습니다.

그래서 `Aricle` 클래스에 `List<Reply>` 필드를 추가해 게시글의 댓글을 관리하도록 하려고 했습니다. 그러나 테이블에 reply id를 복수로 저장하지 않기 때문에 DB에서 Article을 조회할 때 Reply 테이블을 full scan해야했습니다. 결국 해당 방법도 동일하게 Reply 테이블을 full scan 해야한다는 점에서 차이가 없었습니다.
결국 처음 방법대로, 삭제할 때 Reply 테이블에서 해당 게시글을 참조하고 있는 댓글을 찾는 방법을 선택했습니다.
어떻게 하면 1대N 관계에서 더 효율적으로 조회할 수 있을지 고민해봐야 할 것 같습니다.