### PR TITLE
[웨이드] step-5 게시글 권한부여

### DIFF
--- a/src/main/java/codesquad/springcafe/domain/article/Article.java
+++ b/src/main/java/codesquad/springcafe/domain/article/Article.java
@@ -5,12 +5,14 @@ import java.time.LocalDateTime;
 public class Article {
 
     private Long id;
+    private Long userId;
     private String writer;
     private String title;
     private String contents;
     private final LocalDateTime currentTime;
 
-    public Article(String writer, String title, String contents, LocalDateTime currentTime) {
+    public Article(Long userId, String writer, String title, String contents, LocalDateTime currentTime) {
+        this.userId = userId;
         this.writer = writer;
         this.title = title;
         this.contents = contents;
@@ -23,6 +25,10 @@ public class Article {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
     }
 
     public String getWriter() {

--- a/src/main/java/codesquad/springcafe/domain/article/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/ArticleRepository.java
@@ -9,6 +9,7 @@ public interface ArticleRepository {
 
     void save(Article article);
     void update(Long id, ArticleUpdateDto articleUpdateDto);
+    void delete(Long id);
     Optional<Article> findById(Long id);
     List<Article> findAll();
 }

--- a/src/main/java/codesquad/springcafe/domain/article/ArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/ArticleRepository.java
@@ -1,11 +1,14 @@
 package codesquad.springcafe.domain.article;
 
+import codesquad.springcafe.web.dto.ArticleUpdateDto;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface ArticleRepository {
 
     void save(Article article);
+    void update(Long id, ArticleUpdateDto articleUpdateDto);
     Optional<Article> findById(Long id);
     List<Article> findAll();
 }

--- a/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
@@ -26,6 +26,7 @@ public class JdbcArticleRepository implements ArticleRepository {
         jdbcInsert.withTableName("article").usingGeneratedKeyColumns("id");
 
         Map<String, Object> parameters = new HashMap<>();
+        parameters.put("user_id", article.getUserId());
         parameters.put("writer", article.getWriter());
         parameters.put("title", article.getTitle());
         parameters.put("contents", article.getContents());
@@ -50,6 +51,7 @@ public class JdbcArticleRepository implements ArticleRepository {
     private RowMapper<Article> articleRowMapper() {
         return (rs, rowNum) -> {
             Article article = new Article(
+                    rs.getLong("user_id"),
                     rs.getString("writer"),
                     rs.getString("title"),
                     rs.getString("contents"),

--- a/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
@@ -44,6 +44,11 @@ public class JdbcArticleRepository implements ArticleRepository {
     }
 
     @Override
+    public void delete(Long id) {
+        jdbcTemplate.update("delete from article where id = ?", id);
+    }
+
+    @Override
     public Optional<Article> findById(Long id) {
         return jdbcTemplate.query("select * from article where id = ?", articleRowMapper(), id)
                 .stream()

--- a/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/JdbcArticleRepository.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.domain.article;
 
+import codesquad.springcafe.web.dto.ArticleUpdateDto;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -34,6 +35,12 @@ public class JdbcArticleRepository implements ArticleRepository {
 
         Number key = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(parameters));
         article.setId(key.longValue());
+    }
+
+    @Override
+    public void update(Long id, ArticleUpdateDto articleUpdateDto) {
+        jdbcTemplate.update("update article set title = ?, contents = ? where id = ?",
+                articleUpdateDto.getTitle(), articleUpdateDto.getContents(), id);
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/domain/article/MemoryArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/MemoryArticleRepository.java
@@ -26,6 +26,11 @@ public class MemoryArticleRepository implements ArticleRepository {
     }
 
     @Override
+    public void delete(Long id) {
+
+    }
+
+    @Override
     public Optional<Article> findById(Long id) {
         return Optional.ofNullable(articles.get((int) (id - 1)));
     }

--- a/src/main/java/codesquad/springcafe/domain/article/MemoryArticleRepository.java
+++ b/src/main/java/codesquad/springcafe/domain/article/MemoryArticleRepository.java
@@ -1,5 +1,7 @@
 package codesquad.springcafe.domain.article;
 
+import codesquad.springcafe.web.dto.ArticleUpdateDto;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,6 +18,11 @@ public class MemoryArticleRepository implements ArticleRepository {
     @Override
     public void save(Article article) {
         articles.add(article);
+    }
+
+    @Override
+    public void update(Long id, ArticleUpdateDto articleUpdateDto) {
+
     }
 
     @Override

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -32,6 +32,10 @@ public class ArticleService {
         articleRepository.update(id, articleUpdateDto);
     }
 
+    public void deleteArticle(Long id) {
+        articleRepository.delete(id);
+    }
+
     public Article findById(Long id) {
         return articleRepository.findById(id).get();
     }

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -4,6 +4,7 @@ import codesquad.springcafe.domain.article.Article;
 import codesquad.springcafe.domain.article.ArticleRepository;
 import codesquad.springcafe.domain.user.User;
 import codesquad.springcafe.web.dto.ArticleCreateDto;
+import codesquad.springcafe.web.dto.ArticleUpdateDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,6 +26,10 @@ public class ArticleService {
                 articleCreateDto.getContents(),
                 articleCreateDto.getCurrentTime()
         ));
+    }
+
+    public void updateArticle(Long id, ArticleUpdateDto articleUpdateDto) {
+        articleRepository.update(id, articleUpdateDto);
     }
 
     public Article findById(Long id) {

--- a/src/main/java/codesquad/springcafe/service/ArticleService.java
+++ b/src/main/java/codesquad/springcafe/service/ArticleService.java
@@ -2,6 +2,7 @@ package codesquad.springcafe.service;
 
 import codesquad.springcafe.domain.article.Article;
 import codesquad.springcafe.domain.article.ArticleRepository;
+import codesquad.springcafe.domain.user.User;
 import codesquad.springcafe.web.dto.ArticleCreateDto;
 import org.springframework.stereotype.Service;
 
@@ -16,9 +17,10 @@ public class ArticleService {
         this.articleRepository = articleRepository;
     }
 
-    public void saveArticle(ArticleCreateDto articleCreateDto) {
+    public void saveArticle(User loginUser, ArticleCreateDto articleCreateDto) {
         articleRepository.save(new Article(
-                articleCreateDto.getWriter(),
+                loginUser.getId(),
+                loginUser.getUserId(),
                 articleCreateDto.getTitle(),
                 articleCreateDto.getContents(),
                 articleCreateDto.getCurrentTime()

--- a/src/main/java/codesquad/springcafe/web/WebConfig.java
+++ b/src/main/java/codesquad/springcafe/web/WebConfig.java
@@ -1,0 +1,24 @@
+package codesquad.springcafe.web;
+
+import codesquad.springcafe.web.interceptor.LogInterceptor;
+import codesquad.springcafe.web.interceptor.LoginCheckInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/static/**", "/error");
+
+        registry.addInterceptor(new LoginCheckInterceptor())
+                .order(2)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/static/**", "/", "/login", "/logout", "/users/create");
+    }
+}

--- a/src/main/java/codesquad/springcafe/web/WebConfig.java
+++ b/src/main/java/codesquad/springcafe/web/WebConfig.java
@@ -14,11 +14,11 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LogInterceptor())
                 .order(1)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/css/**", "/images/**", "/*.ico", "/error");
+                .excludePathPatterns("/css/**", "/images/**", "/*.ico", "/fonts/**", "/js/**", "/error");
 
         registry.addInterceptor(new LoginCheckInterceptor())
                 .order(2)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/", "/css/**", "/images/**", "/*.ico", "/error", "/login", "/logout", "/users/create");
+                .excludePathPatterns("/", "/css/**", "/images/**", "/*.ico", "/fonts/**", "/js/**", "/error", "/login", "/logout", "/users/create");
     }
 }

--- a/src/main/java/codesquad/springcafe/web/WebConfig.java
+++ b/src/main/java/codesquad/springcafe/web/WebConfig.java
@@ -14,11 +14,11 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(new LogInterceptor())
                 .order(1)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/static/**", "/error");
+                .excludePathPatterns("/css/**", "/images/**", "/*.ico", "/error");
 
         registry.addInterceptor(new LoginCheckInterceptor())
                 .order(2)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/static/**", "/", "/login", "/logout", "/users/create");
+                .excludePathPatterns("/", "/css/**", "/images/**", "/*.ico", "/error", "/login", "/logout", "/users/create");
     }
 }

--- a/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
@@ -74,4 +74,10 @@ public class ArticleController {
         articleService.updateArticle(id, articleUpdateDto);
         return "redirect:/";
     }
+
+    @DeleteMapping("/articles/{id}/delete")
+    public String deleteArticle(@PathVariable Long id) {
+        articleService.deleteArticle(id);
+        return "redirect:/";
+    }
 }

--- a/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
@@ -1,5 +1,6 @@
 package codesquad.springcafe.web.controller;
 
+import codesquad.springcafe.domain.user.User;
 import codesquad.springcafe.service.ArticleService;
 import codesquad.springcafe.web.dto.ArticleCreateDto;
 import codesquad.springcafe.web.validation.ArticleCreateValidator;
@@ -33,11 +34,14 @@ public class ArticleController {
     }
 
     @PostMapping("/articles/create")
-    public String quest(@Validated @ModelAttribute("create") ArticleCreateDto articleCreateDto, BindingResult bindingResult) {
+    public String quest(
+            @SessionAttribute(name = "loginUser", required = false) User loginUser,
+            @Validated @ModelAttribute("create") ArticleCreateDto articleCreateDto,
+            BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "qna/form";
         }
-        articleService.saveArticle(articleCreateDto);
+        articleService.saveArticle(loginUser, articleCreateDto);
         return "redirect:/";
     }
 

--- a/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
+++ b/src/main/java/codesquad/springcafe/web/controller/ArticleController.java
@@ -3,6 +3,7 @@ package codesquad.springcafe.web.controller;
 import codesquad.springcafe.domain.user.User;
 import codesquad.springcafe.service.ArticleService;
 import codesquad.springcafe.web.dto.ArticleCreateDto;
+import codesquad.springcafe.web.dto.ArticleUpdateDto;
 import codesquad.springcafe.web.validation.ArticleCreateValidator;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -56,5 +57,21 @@ public class ArticleController {
     public String questionList(Model model) {
         model.addAttribute("articles", articleService.getArticles());
         return "index";
+    }
+
+    @GetMapping("/articles/{id}/update")
+    public String updateArticle(@PathVariable Long id, Model model) {
+        model.addAttribute("article", articleService.findById(id));
+        return "qna/updateForm";
+    }
+
+    @PutMapping("/articles/{id}/update")
+    public String updateArticle(
+            @SessionAttribute(name = "loginUser", required = false) User loginUser,
+            @PathVariable Long id,
+            @ModelAttribute ArticleUpdateDto articleUpdateDto) {
+        // 로그인된 사용자가 글의 주인인지 검증하는 로직 추가 예정
+        articleService.updateArticle(id, articleUpdateDto);
+        return "redirect:/";
     }
 }

--- a/src/main/java/codesquad/springcafe/web/dto/ArticleCreateDto.java
+++ b/src/main/java/codesquad/springcafe/web/dto/ArticleCreateDto.java
@@ -4,21 +4,12 @@ import java.time.LocalDateTime;
 
 public class ArticleCreateDto {
 
-    private String writer;
     private String title;
     private String contents;
     private LocalDateTime currentTime;
 
     public ArticleCreateDto() {
         this.currentTime = LocalDateTime.now();
-    }
-
-    public String getWriter() {
-        return writer;
-    }
-
-    public void setWriter(String writer) {
-        this.writer = writer;
     }
 
     public String getTitle() {
@@ -39,9 +30,5 @@ public class ArticleCreateDto {
 
     public LocalDateTime getCurrentTime() {
         return currentTime;
-    }
-
-    public void setCurrentTime(LocalDateTime currentTime) {
-        this.currentTime = currentTime;
     }
 }

--- a/src/main/java/codesquad/springcafe/web/dto/ArticleUpdateDto.java
+++ b/src/main/java/codesquad/springcafe/web/dto/ArticleUpdateDto.java
@@ -1,0 +1,20 @@
+package codesquad.springcafe.web.dto;
+
+public class ArticleUpdateDto {
+
+    private String title;
+    private String contents;
+
+    public ArticleUpdateDto(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+}

--- a/src/main/java/codesquad/springcafe/web/interceptor/LogInterceptor.java
+++ b/src/main/java/codesquad/springcafe/web/interceptor/LogInterceptor.java
@@ -1,0 +1,40 @@
+package codesquad.springcafe.web.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.UUID;
+
+public class LogInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(LogInterceptor.class);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        String logId = UUID.randomUUID().toString();
+        request.setAttribute("logId", logId);
+        log.info("Request [{}][{}][{}]", logId, requestURI, handler);
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("Post Handle [{}]", modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        String requestURI = request.getRequestURI();
+        String logId = (String) request.getAttribute("logId");
+        log.info("Response [{}][{}][{}]", logId, requestURI, handler);
+
+        if (ex != null) {
+            log.error("After Completion Error", ex);
+        }
+    }
+}

--- a/src/main/java/codesquad/springcafe/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/codesquad/springcafe/web/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,27 @@
+package codesquad.springcafe.web.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(LoginCheckInterceptor.class);
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = request.getRequestURI();
+        log.info("Login Check Interceptor {}", requestURI);
+
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("loginUser") == null) {
+            log.info("미인증 사용자 요청");
+            response.sendRedirect("/login?redirectURL=" + requestURI);
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/codesquad/springcafe/web/validation/ArticleCreateValidator.java
+++ b/src/main/java/codesquad/springcafe/web/validation/ArticleCreateValidator.java
@@ -18,9 +18,6 @@ public class ArticleCreateValidator implements Validator {
     public void validate(Object target, Errors errors) {
         ArticleCreateDto articleCreateDto = (ArticleCreateDto) target;
 
-        if (!StringUtils.hasText(articleCreateDto.getWriter())) {
-            errors.rejectValue("writer", "temporary", null, "작성자를 입력하세요.");
-        }
         if (!StringUtils.hasText(articleCreateDto.getTitle())) {
             errors.rejectValue("title", "temporary", null, "제목을 입력하세요.");
         }

--- a/src/main/resources/templates/fragment/navbar.html
+++ b/src/main/resources/templates/fragment/navbar.html
@@ -61,6 +61,7 @@
                     <li class="active"><a href="../index.html">Posts</a></li>
                     <li th:if="${session.loginUser == null}"><a href="/login" role="button">로그인</a></li>
                     <li th:if="${session.loginUser == null}"><a href="/users/create" role="button">회원가입</a></li>
+
                     <li th:if="${session.loginUser != null}"><a href="/logout" role="button">로그아웃</a></li>
                     <li th:if="${session.loginUser != null}"><a th:href="@{/users/{userId}/update(userId=${session.loginUser.getUserId()})}" role="button">개인정보수정</a></li>
                 </ul>

--- a/src/main/resources/templates/fragment/script.html
+++ b/src/main/resources/templates/fragment/script.html
@@ -6,9 +6,9 @@
 </head>
 <body>
 <div th:fragment="script">
-    <script src="../../static/js/jquery-2.2.0.min.js">
-    <script src="../../static/js/bootstrap.min.js"></script>
-    <script src="../../static/js/scripts.js"></script>
+    <script th:src="@{/js/jquery-2.2.0.min.js}"></script>
+    <script th:src="@{/js/bootstrap.min.js}"></script>
+    <script th:src="@{/js/scripts.js}"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/qna/form.html
+++ b/src/main/resources/templates/qna/form.html
@@ -19,12 +19,6 @@
       <div class="panel panel-default content-main">
           <form name="question" method="post" action="/articles/create" th:object="${create}">
               <div class="form-group">
-                  <label for="writer">작성자</label>
-                  <input class="form-control" id="writer" name="writer" placeholder="작성자"
-                         th:field="*{writer}" th:errorclass="field-error-input"/>
-                  <div class="field-error" th:errors="*{writer}">작성자 에러</div>
-              </div>
-              <div class="form-group">
                   <label for="title">제목</label>
                   <input type="text" class="form-control" id="title" name="title" placeholder="제목"
                          th:field="*{title}" th:errorclass="field-error-input"/>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -29,8 +29,8 @@
                   <div class="article-doc" th:utext="${#strings.replace(article.getContents(), nlString, '&lt;br /&gt;')}">contents</div>
                   <div class="article-util">
                       <ul class="article-util-list">
-                          <li>
-                              <a class="link-modify-article" href="/questions/423/form">수정</a>
+                          <li th:if="${session.loginUser.getId() == article.getUserId()}">
+                              <a class="link-modify-article" th:href="@{/articles/{id}/update(id=${article.getId()})}">수정</a>
                           </li>
                           <li>
                               <form class="form-delete" action="/questions/423" method="POST">

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -32,9 +32,8 @@
                           <li th:if="${session.loginUser.getId() == article.getUserId()}">
                               <a class="link-modify-article" th:href="@{/articles/{id}/update(id=${article.getId()})}">수정</a>
                           </li>
-                          <li>
-                              <form class="form-delete" action="/questions/423" method="POST">
-                                  <input type="hidden" name="_method" value="DELETE">
+                          <li th:if="${session.loginUser.getId() == article.getUserId()}">
+                              <form class="form-delete" th:action="@{/articles/{id}/delete(id=${article.getId()})}" th:method="delete">
                                   <button class="link-delete-article" type="submit">삭제</button>
                               </form>
                           </li>

--- a/src/main/resources/templates/qna/show.html
+++ b/src/main/resources/templates/qna/show.html
@@ -19,7 +19,7 @@
                           <img src="https://graph.facebook.com/v2.3/100000059371774/picture" class="article-author-thumb" alt="">
                       </div>
                       <div class="article-header-text">
-                          <a href="/users/92/kimmunsu" class="article-author-name">작성자</a>
+                          <a href="/users/92/kimmunsu" class="article-author-name" th:text="${article.getWriter()}">작성자</a>
                           <a href="/questions/413" class="article-header-time" title="퍼머링크" th:text="${#temporals.format(article.getCurrentTime(), 'yyyy-MM-dd HH:mm:ss')}">
                               currentTime
                               <i class="icon-link"></i>

--- a/src/main/resources/templates/qna/updateForm.html
+++ b/src/main/resources/templates/qna/updateForm.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="kr">
+<head>
+    <div th:insert="~{fragment/header :: header}"></div>
+</head>
+<body>
+<div th:insert="~{fragment/navbar :: mainNav}"></div>
+<div th:insert="~{fragment/navbar :: subNav}"></div>
+<div class="container" id="main">
+   <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
+      <div class="panel panel-default content-main">
+          <form name="question" th:method="put" th:action="@{/articles/{id}/update(id=${article.getId()})}">
+              <div class="form-group">
+                  <label for="title">제목</label>
+                  <input type="text" class="form-control" id="title" name="title" placeholder="제목" th:value="${article.getTitle()}"/>
+              </div>
+              <div class="form-group">
+                  <label for="contents">내용</label>
+                  <textarea name="contents" id="contents" rows="5" class="form-control" th:text="${article.getContents()}"></textarea>
+              </div>
+              <button type="submit" class="btn btn-success clearfix pull-right">수정하기</button>
+              <div class="clearfix" />
+          </form>
+        </div>
+    </div>
+</div>
+
+<!-- script references -->
+<div th:insert="~{fragment/script :: script}"></div>
+</body>
+</html>


### PR DESCRIPTION
## 구현 내용

### 스프링 인터셉터

`preHandle` : 핸들러 어댑터 호출 전에 호출됩니다.
`postHandle` : 핸들러 어댑터 호출 후에 호출됩니다.
`afterCompletion` : 뷰가 렌더링 된 이후에 호출됩니다. (예외가 발생해도 호출되는 것이 보장됩니다)

- LogInterceptor
  - 각 흐름에 따라, 요청 로그 정보를 출력합니다. 
- LoginCheckInterceptor
  - preHandle를 사용해서 인증된 사용자의 요청인지에 따라 다음 진행 여부를 판단합니다.
- WebConfig
  - 인터셉터를 등록하고, 적용 경로와 제외 경로를 설정해 줍니다.

### 게시글 작성, 수정, 삭제

- 작성
  - 글 작성 form에서 작성자 입력 필드를 삭제하고, Article 클래스에 Long 타입의 userId 필드를 추가합니다. (DB에서 FK 설정도 추가합니다.)
  - 글 작성 시, 작성된 글 객체는 로그인 돼있는 유저의 id값을 FK로 갖게 됩니다.
- 수정 ("/articles/{id}/update")
  - `th:if="${session.loginUser.getId() == article.getUserId()}"`를 사용해서 글의 수정은 작성자(로그인 돼 있는 유저)만이 할 수 있도록 설정했습니다. (서버 단에서의 검증 로직도 추가 예정입니다)
  - `Get`
    - 글 수정 form을 반환합니다. 이때, 경로 변수인 id를 통해 해당 글을 찾아서 form에 글의 정보를 반영해줍니다.
  - `Put`
    - update 문을 통해, 경로 변수인 id에 해당하는 객체가 수정 form을 통해 넘어온 정보를 담도록 합니다. 
- 삭제 ("/articles/{id}/delete")
  - 수정과 마찬가지로 작성자(로그인 돼 있는 유저)만이 할 수 있도록 설정했습니다.
  - `Delete`
    - delete 문을 통해, 경로 변수인 id에 해당하는 글이 제거되도록 합니다. 

## 고민 사항

- Dto를 그대로 Service로 넘기는 게 괜찮은지 생각해보라고 피드백을 주셨는데, Dto에 대한 이해가 부족한 만큼 어떤 부분에서 고민해야 할지 잘 이해가 되지 않았습니다. 이에 대한 학습도 천천히 진행해 보려 합니다.